### PR TITLE
Escape single quotes in string literals

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -147,7 +147,7 @@ function buildFilter(filters = {}, propPrefix = '') {
 
 function handleValue(value) {
   if (typeof(value) === 'string') {
-    return `'${value}'`
+    return `'${value.replace("'", "''")}'`
   } else if (value instanceof Date) {
     return value.toISOString();
   } else {

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -236,6 +236,13 @@ describe('filter', () => {
       expect(actual).toEqual(expected);
     });
 
+    it("should escape the `'` character in strings", () => {
+      const filter = { StringProp: "O'Dimm" };
+      const expected = "?$filter=StringProp eq 'O''Dimm'"
+      const actual = buildQuery({ filter });
+      expect(actual).toEqual(expected);
+    });
+
     it('should handle a boolean', () => {
       const filter = { BooleanProp: true };
       const expected = "?$filter=BooleanProp eq true"


### PR DESCRIPTION
Single quotes in string literals don't get escaped when handling a value. This escapes them properly.