### PR TITLE
Add parenthesis around 'in' operator

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -6,43 +6,45 @@ const SUPPORTED_EXPAND_PROPERTIES = ['expand', 'select', 'top', 'orderby', 'filt
 
 const FUNCTION_REGEX = /\((.*)\)/;
 
-export default function ({ select, filter, search, groupBy, transform, orderBy, top, skip, key, count, expand, action, func } = {}) {
+export default function ({select, filter, search, groupBy, transform, orderBy, top, skip, key, count, expand, action, func} = {}) {
   let path = '';
   const params = {};
 
   if (select) {
-    params.$select = select
+    params.$select = select;
   }
 
   if (filter || count instanceof Object) {
-    const builtFilter = buildFilter(count instanceof Object ? count : filter)
+    const builtFilter = buildFilter(count instanceof Object
+                                    ? count
+                                    : filter);
     if (builtFilter !== undefined) {
-      params.$filter = builtFilter
+      params.$filter = builtFilter;
     }
   }
 
   if (search) {
-    params.$search = search
+    params.$search = search;
   }
 
   if (transform) {
     const builtTransforms = buildTransforms(transform);
     if (builtTransforms !== undefined) {
-      params.$apply = builtTransforms
+      params.$apply = builtTransforms;
     }
   }
 
   if (top) {
-    params.$top = top
+    params.$top = top;
   }
 
   if (skip) {
-    params.$skip = skip
+    params.$skip = skip;
   }
 
   if (key) {
     if (typeof(key) === 'object') {
-      const keys = Object.keys(key).map(k => `${k}=${key[k]}`).join(',')
+      const keys = Object.keys(key).map(k => `${k}=${key[k]}`).join(',');
       path += `(${keys})`;
     } else {
       path += `(${key})`;
@@ -51,7 +53,7 @@ export default function ({ select, filter, search, groupBy, transform, orderBy, 
 
   if (count) {
     if (typeof(count) === 'boolean') {
-      params.$count = true
+      params.$count = true;
     } else {
       path += '/$count';
     }
@@ -66,7 +68,7 @@ export default function ({ select, filter, search, groupBy, transform, orderBy, 
       path += `/${func}`;
     } else if (typeof(func) === 'object') {
       const [funcName] = Object.keys(func);
-      const funcParams = Object.keys(func[funcName]).map(p => `${p}=${func[funcName][p]}`).join(',')
+      const funcParams = Object.keys(func[funcName]).map(p => `${p}=${func[funcName][p]}`).join(',');
 
       path += `/${funcName}`;
       if (funcParams.length) {
@@ -76,121 +78,124 @@ export default function ({ select, filter, search, groupBy, transform, orderBy, 
   }
 
   if (expand) {
-    params.$expand = buildExpand(expand)
+    params.$expand = buildExpand(expand);
   }
 
   if (orderBy) {
-    params.$orderby = buildOrderBy(orderBy)
+    params.$orderby = buildOrderBy(orderBy);
   }
 
-  return buildUrl(path, params)
+  return buildUrl(path, params);
 }
 
 function buildFilter(filters = {}, propPrefix = '') {
   if (filters == null) {
     // ignore `null` and `undefined` filters (useful for conditionally applied filters)
-    return
+    return;
   } else if (typeof(filters) === 'string') {
     // Use raw filter string
     return filters;
   } else if (Array.isArray(filters)) {
     const builtFilters = filters.map(f => buildFilter(f, propPrefix)).filter(f => f !== undefined);
     if (builtFilters.length) {
-      return `${builtFilters.map(f => `(${f})`).join(` and `)}`
+      return `${builtFilters.map(f => `(${f})`).join(` and `)}`;
     }
   } else if (typeof(filters) === 'object') {
     const filtersArray = Object.keys(filters).reduce((result, filterKey) => {
       const value = filters[filterKey];
-      const propName = propPrefix ?
-        (FUNCTION_REGEX.test(filterKey) ? filterKey.replace(FUNCTION_REGEX, `(${propPrefix}/$1)`) : `${propPrefix}/${filterKey}`)
-        : filterKey;
+      const propName = propPrefix
+                       ?
+                       (FUNCTION_REGEX.test(filterKey)
+                        ? filterKey.replace(FUNCTION_REGEX, `(${propPrefix}/$1)`)
+                        : `${propPrefix}/${filterKey}`)
+                       : filterKey;
 
       if (["number", "string", "boolean"].indexOf(typeof(value)) !== -1 || value instanceof Date || value === null) {
         // Simple key/value handled as equals operator
-        result.push(`${propName} eq ${handleValue(value)}`)
+        result.push(`${propName} eq ${handleValue(value)}`);
       } else if (Array.isArray(value)) {
         const op = filterKey;
         const builtFilters = value.map(v => buildFilter(v, propPrefix)).filter(f => f !== undefined);
         if (builtFilters.length) {
-          result.push(`(${builtFilters.join(` ${op} `)})`)
+          result.push(`(${builtFilters.join(` ${op} `)})`);
         }
       } else if (LOGICAL_OPERATORS.indexOf(propName) !== -1) {
-        const builtFilters = Object.keys(value).map(valueKey => buildFilter({ [valueKey]: value[valueKey] }));
+        const builtFilters = Object.keys(value).map(valueKey => buildFilter({[valueKey]: value[valueKey]}));
         if (builtFilters.length) {
-          result.push(`${builtFilters.join(` ${propName} `)}`)
+          result.push(`${builtFilters.join(` ${propName} `)}`);
         }
       } else if (value instanceof Object) {
         const operators = Object.keys(value);
         operators.forEach(op => {
           if ([...COMPARISON_OPERATORS, ...LOGICAL_OPERATORS].indexOf(op) !== -1) {
-            result.push(`${propName} ${op} ${handleValue(value[op])}`)
+            result.push(`${propName} ${op} ${handleValue(value[op])}`);
           } else if (COLLECTION_OPERATORS.indexOf(op) !== -1) {
             const lambaParameter = propName[0].toLowerCase();
             const filter = buildFilter(value[op], lambaParameter);
 
             if (filter !== undefined) {
               // Do not apply collection filter if undefined (ex. ignore `Foo: { any: {} }`)
-              result.push(`${propName}/${op}(${lambaParameter}:${filter})`)
+              result.push(`${propName}/${op}(${lambaParameter}:${filter})`);
             }
           } else if (op === 'in') {
             // Convert `{ Prop: { in: [1,2,3] } }` to `Prop eq 1 or Prop eq 2 or Prop eq 3`
             result.push('(' + value[op].map(v => `${propName} eq ${handleValue(v)}`).join(' or ') + ')')
           } else if (BOOLEAN_FUNCTIONS.indexOf(op) !== -1) {
             // Simple boolean functions (startswith, endswith, contains)
-            result.push(`${op}(${propName},${handleValue(value[op])})`)
+            result.push(`${op}(${propName},${handleValue(value[op])})`);
           } else {
             // Nested property
             result.push(buildFilter(value, propName));
           }
-        })
+        });
       } else if (value === undefined) {
         // Ignore/omit filter if value is `undefined`
       } else {
-        throw new Error(`Unexpected value type: ${value}`)
+        throw new Error(`Unexpected value type: ${value}`);
       }
 
       return result;
-    }, [])
+    }, []);
 
     return filtersArray.join(' and ') || undefined;
   } else {
-    throw new Error(`Unexpected filters type: ${filters}`)
+    throw new Error(`Unexpected filters type: ${filters}`);
   }
 }
 
 function handleValue(value) {
   if (typeof(value) === 'string') {
-    return `'${value.replace("'", "''")}'`
+    return `'${value.replace("'", "''")}'`;
   } else if (value instanceof Date) {
     return value.toISOString();
   } else {
     // TODO: Figure out how best to specify types.  See: https://github.com/devnixs/ODataAngularResources/blob/master/src/odatavalue.js
-    return value
+    return value;
   }
 }
 
 function buildExpand(expands) {
   if (typeof(expands) === 'number') {
-    return expands
+    return expands;
   } else if (typeof(expands) === 'string') {
 
     if (expands.indexOf('/') === -1) {
-      return expands
+      return expands;
     }
 
     // Change `Foo/Bar/Baz` to `Foo($expand=Bar($expand=Baz))`
     return expands.split('/').reverse().reduce((results, item, index, arr) => {
       if (index === 0) {
         // Inner-most item
-        return `$expand=${item}`
-      } else if(index === arr.length - 1) {
+        return `$expand=${item}`;
+      } else if (index === arr.length - 1) {
         // Outer-most item, don't add `$expand=` prefix (added above)
-        return `${item}(${results})`
+        return `${item}(${results})`;
       } else {
         // Other items
-        return `$expand=${item}(${results})`
+        return `$expand=${item}(${results})`;
       }
-    }, '')
+    }, '');
   } else if (Array.isArray(expands)) {
     return `${expands.map(e => buildExpand(e)).join(',')}`;
   } else if (typeof(expands) === 'object') {
@@ -199,61 +204,71 @@ function buildExpand(expands) {
     if (expandKeys.some(key => SUPPORTED_EXPAND_PROPERTIES.indexOf(key.toLowerCase()) !== -1)) {
       return expandKeys.map(key => {
         const value =
-          key === 'filter' ? buildFilter(expands[key]) :
-          key.toLowerCase() === 'orderby' ? buildOrderBy(expands[key]) :
+          key === 'filter'
+          ? buildFilter(expands[key])
+          :
+          key.toLowerCase() === 'orderby'
+          ? buildOrderBy(expands[key])
+          :
           buildExpand(expands[key]);
-        return `$${key.toLowerCase()}=${value}`
+        return `$${key.toLowerCase()}=${value}`;
       })
-      .join(';')
+        .join(';');
     } else {
       return expandKeys.map(key => {
         const builtExpand = buildExpand(expands[key]);
-        return builtExpand ? `${key}(${builtExpand})` : key;
+        return builtExpand
+               ? `${key}(${builtExpand})`
+               : key;
       })
-      .join(',')
+        .join(',');
     }
   }
 }
 
 function buildTransforms(transforms) {
   // Wrap single object an array for simplified processing
-  const transformsArray = Array.isArray(transforms) ? transforms : [transforms];
+  const transformsArray = Array.isArray(transforms)
+                          ? transforms
+                          : [transforms];
 
   const transformsResult = transformsArray.reduce((result, transform) => {
     Object.keys(transform).forEach(transformKey => {
       const transformValue = transform[transformKey];
-      switch(transformKey) {
+      switch (transformKey) {
         case 'aggregate':
-          result.push(`aggregate(${buildAggregate(transformValue)})`)
+          result.push(`aggregate(${buildAggregate(transformValue)})`);
           break;
         case 'filter':
           const builtFilter = buildFilter(transformValue);
           if (builtFilter !== undefined) {
-            result.push(`filter(${buildFilter(transformValue)})`)
+            result.push(`filter(${buildFilter(transformValue)})`);
           }
           break;
         case 'groupby': // support both cases
         case 'groupBy':
-          result.push(`groupby(${buildGroupBy(transformValue)})`)
+          result.push(`groupby(${buildGroupBy(transformValue)})`);
           break;
         default:
           // TODO: support as many of the following:
           //   topcount, topsum, toppercent,
           //   bottomsum, bottomcount, bottompercent,
           //   identity, concat, expand, search, compute, isdefined
-          throw new Error(`Unsupported transform: '${transformKey}'`)
+          throw new Error(`Unsupported transform: '${transformKey}'`);
       }
-    })
+    });
 
     return result;
-  }, [])
+  }, []);
 
   return transformsResult.join('/') || undefined;
 }
 
 function buildAggregate(aggregate) {
   // Wrap single object in an array for simplified processing
-  const aggregateArray = Array.isArray(aggregate) ? aggregate : [aggregate];
+  const aggregateArray = Array.isArray(aggregate)
+                         ? aggregate
+                         : [aggregate];
 
   return aggregateArray.map(aggregateItem => {
     return Object.keys(aggregateItem).map(aggregateKey => {
@@ -261,20 +276,20 @@ function buildAggregate(aggregate) {
 
       // TODO: Are these always required?  Can/should we default them if so?
       if (aggregateValue.with === undefined) {
-        throw new Error(`'with' property required for '${aggregateKey}'`)
+        throw new Error(`'with' property required for '${aggregateKey}'`);
       }
       if (aggregateValue.as === undefined) {
-        throw new Error(`'as' property required for '${aggregateKey}'`)
+        throw new Error(`'as' property required for '${aggregateKey}'`);
       }
 
-      return `${aggregateKey} with ${aggregateValue.with} as ${aggregateValue.as}`
-    })
-  }).join(',')
+      return `${aggregateKey} with ${aggregateValue.with} as ${aggregateValue.as}`;
+    });
+  }).join(',');
 }
 
 function buildGroupBy(groupBy) {
   if (groupBy.properties === undefined) {
-    throw new Error(`'properties' property required for groupBy:'${aggregateKey}'`)
+    throw new Error(`'properties' property required for groupBy:'${aggregateKey}'`);
   }
 
   let result = `(${groupBy.properties.join(',')})`;
@@ -288,9 +303,9 @@ function buildGroupBy(groupBy) {
 
 function buildOrderBy(orderBy) {
   if (typeof(orderBy) === 'number') {
-    return orderBy
+    return orderBy;
   } else if (typeof(orderBy) === 'string') {
-    return orderBy
+    return orderBy;
   } else if (Array.isArray(orderBy)) {
     return `${orderBy.map(o => buildOrderBy(o)).join(',')}`;
   }

--- a/src/index.js
+++ b/src/index.js
@@ -6,45 +6,43 @@ const SUPPORTED_EXPAND_PROPERTIES = ['expand', 'select', 'top', 'orderby', 'filt
 
 const FUNCTION_REGEX = /\((.*)\)/;
 
-export default function ({select, filter, search, groupBy, transform, orderBy, top, skip, key, count, expand, action, func} = {}) {
+export default function ({ select, filter, search, groupBy, transform, orderBy, top, skip, key, count, expand, action, func } = {}) {
   let path = '';
   const params = {};
 
   if (select) {
-    params.$select = select;
+    params.$select = select
   }
 
   if (filter || count instanceof Object) {
-    const builtFilter = buildFilter(count instanceof Object
-                                    ? count
-                                    : filter);
+    const builtFilter = buildFilter(count instanceof Object ? count : filter)
     if (builtFilter !== undefined) {
-      params.$filter = builtFilter;
+      params.$filter = builtFilter
     }
   }
 
   if (search) {
-    params.$search = search;
+    params.$search = search
   }
 
   if (transform) {
     const builtTransforms = buildTransforms(transform);
     if (builtTransforms !== undefined) {
-      params.$apply = builtTransforms;
+      params.$apply = builtTransforms
     }
   }
 
   if (top) {
-    params.$top = top;
+    params.$top = top
   }
 
   if (skip) {
-    params.$skip = skip;
+    params.$skip = skip
   }
 
   if (key) {
     if (typeof(key) === 'object') {
-      const keys = Object.keys(key).map(k => `${k}=${key[k]}`).join(',');
+      const keys = Object.keys(key).map(k => `${k}=${key[k]}`).join(',')
       path += `(${keys})`;
     } else {
       path += `(${key})`;
@@ -53,7 +51,7 @@ export default function ({select, filter, search, groupBy, transform, orderBy, t
 
   if (count) {
     if (typeof(count) === 'boolean') {
-      params.$count = true;
+      params.$count = true
     } else {
       path += '/$count';
     }
@@ -68,7 +66,7 @@ export default function ({select, filter, search, groupBy, transform, orderBy, t
       path += `/${func}`;
     } else if (typeof(func) === 'object') {
       const [funcName] = Object.keys(func);
-      const funcParams = Object.keys(func[funcName]).map(p => `${p}=${func[funcName][p]}`).join(',');
+      const funcParams = Object.keys(func[funcName]).map(p => `${p}=${func[funcName][p]}`).join(',')
 
       path += `/${funcName}`;
       if (funcParams.length) {
@@ -78,124 +76,121 @@ export default function ({select, filter, search, groupBy, transform, orderBy, t
   }
 
   if (expand) {
-    params.$expand = buildExpand(expand);
+    params.$expand = buildExpand(expand)
   }
 
   if (orderBy) {
-    params.$orderby = buildOrderBy(orderBy);
+    params.$orderby = buildOrderBy(orderBy)
   }
 
-  return buildUrl(path, params);
+  return buildUrl(path, params)
 }
 
 function buildFilter(filters = {}, propPrefix = '') {
   if (filters == null) {
     // ignore `null` and `undefined` filters (useful for conditionally applied filters)
-    return;
+    return
   } else if (typeof(filters) === 'string') {
     // Use raw filter string
     return filters;
   } else if (Array.isArray(filters)) {
     const builtFilters = filters.map(f => buildFilter(f, propPrefix)).filter(f => f !== undefined);
     if (builtFilters.length) {
-      return `${builtFilters.map(f => `(${f})`).join(` and `)}`;
+      return `${builtFilters.map(f => `(${f})`).join(` and `)}`
     }
   } else if (typeof(filters) === 'object') {
     const filtersArray = Object.keys(filters).reduce((result, filterKey) => {
       const value = filters[filterKey];
-      const propName = propPrefix
-                       ?
-                       (FUNCTION_REGEX.test(filterKey)
-                        ? filterKey.replace(FUNCTION_REGEX, `(${propPrefix}/$1)`)
-                        : `${propPrefix}/${filterKey}`)
-                       : filterKey;
+      const propName = propPrefix ?
+        (FUNCTION_REGEX.test(filterKey) ? filterKey.replace(FUNCTION_REGEX, `(${propPrefix}/$1)`) : `${propPrefix}/${filterKey}`)
+        : filterKey;
 
       if (["number", "string", "boolean"].indexOf(typeof(value)) !== -1 || value instanceof Date || value === null) {
         // Simple key/value handled as equals operator
-        result.push(`${propName} eq ${handleValue(value)}`);
+        result.push(`${propName} eq ${handleValue(value)}`)
       } else if (Array.isArray(value)) {
         const op = filterKey;
         const builtFilters = value.map(v => buildFilter(v, propPrefix)).filter(f => f !== undefined);
         if (builtFilters.length) {
-          result.push(`(${builtFilters.join(` ${op} `)})`);
+          result.push(`(${builtFilters.join(` ${op} `)})`)
         }
       } else if (LOGICAL_OPERATORS.indexOf(propName) !== -1) {
-        const builtFilters = Object.keys(value).map(valueKey => buildFilter({[valueKey]: value[valueKey]}));
+        const builtFilters = Object.keys(value).map(valueKey => buildFilter({ [valueKey]: value[valueKey] }));
         if (builtFilters.length) {
-          result.push(`${builtFilters.join(` ${propName} `)}`);
+          result.push(`${builtFilters.join(` ${propName} `)}`)
         }
       } else if (value instanceof Object) {
         const operators = Object.keys(value);
         operators.forEach(op => {
           if ([...COMPARISON_OPERATORS, ...LOGICAL_OPERATORS].indexOf(op) !== -1) {
-            result.push(`${propName} ${op} ${handleValue(value[op])}`);
+            result.push(`${propName} ${op} ${handleValue(value[op])}`)
           } else if (COLLECTION_OPERATORS.indexOf(op) !== -1) {
             const lambaParameter = propName[0].toLowerCase();
             const filter = buildFilter(value[op], lambaParameter);
 
             if (filter !== undefined) {
               // Do not apply collection filter if undefined (ex. ignore `Foo: { any: {} }`)
-              result.push(`${propName}/${op}(${lambaParameter}:${filter})`);
+              result.push(`${propName}/${op}(${lambaParameter}:${filter})`)
             }
           } else if (op === 'in') {
-            // Convert `{ Prop: { in: [1,2,3] } }` to `Prop eq 1 or Prop eq 2 or Prop eq 3`
+            // Convert `{ Prop: { in: [1,2,3] } }` to `(Prop eq 1 or Prop eq 2 or Prop eq 3)`
             result.push('(' + value[op].map(v => `${propName} eq ${handleValue(v)}`).join(' or ') + ')')
           } else if (BOOLEAN_FUNCTIONS.indexOf(op) !== -1) {
             // Simple boolean functions (startswith, endswith, contains)
-            result.push(`${op}(${propName},${handleValue(value[op])})`);
+            result.push(`${op}(${propName},${handleValue(value[op])})`)
           } else {
             // Nested property
             result.push(buildFilter(value, propName));
           }
-        });
+        })
       } else if (value === undefined) {
         // Ignore/omit filter if value is `undefined`
       } else {
-        throw new Error(`Unexpected value type: ${value}`);
+        throw new Error(`Unexpected value type: ${value}`)
       }
 
       return result;
-    }, []);
+    }, [])
 
     return filtersArray.join(' and ') || undefined;
   } else {
-    throw new Error(`Unexpected filters type: ${filters}`);
+    throw new Error(`Unexpected filters type: ${filters}`)
   }
 }
 
 function handleValue(value) {
   if (typeof(value) === 'string') {
-    return `'${value.replace("'", "''")}'`;
+    return `'${value.replace("'", "''")}'`
   } else if (value instanceof Date) {
     return value.toISOString();
   } else {
     // TODO: Figure out how best to specify types.  See: https://github.com/devnixs/ODataAngularResources/blob/master/src/odatavalue.js
-    return value;
+    return value
   }
 }
 
 function buildExpand(expands) {
   if (typeof(expands) === 'number') {
-    return expands;
+    return expands
   } else if (typeof(expands) === 'string') {
 
     if (expands.indexOf('/') === -1) {
-      return expands;
+      return expands
     }
 
     // Change `Foo/Bar/Baz` to `Foo($expand=Bar($expand=Baz))`
     return expands.split('/').reverse().reduce((results, item, index, arr) => {
       if (index === 0) {
         // Inner-most item
-        return `$expand=${item}`;
-      } else if (index === arr.length - 1) {
+        return `$expand=${item}`
+      } else if(index === arr.length - 1) {
         // Outer-most item, don't add `$expand=` prefix (added above)
-        return `${item}(${results})`;
+        return `${item}(${results})`
       } else {
         // Other items
-        return `$expand=${item}(${results})`;
+        return `$expand=${item}(${results})`
       }
-    }, '');
+    }, '')
   } else if (Array.isArray(expands)) {
     return `${expands.map(e => buildExpand(e)).join(',')}`;
   } else if (typeof(expands) === 'object') {
@@ -204,71 +199,61 @@ function buildExpand(expands) {
     if (expandKeys.some(key => SUPPORTED_EXPAND_PROPERTIES.indexOf(key.toLowerCase()) !== -1)) {
       return expandKeys.map(key => {
         const value =
-          key === 'filter'
-          ? buildFilter(expands[key])
-          :
-          key.toLowerCase() === 'orderby'
-          ? buildOrderBy(expands[key])
-          :
+          key === 'filter' ? buildFilter(expands[key]) :
+          key.toLowerCase() === 'orderby' ? buildOrderBy(expands[key]) :
           buildExpand(expands[key]);
-        return `$${key.toLowerCase()}=${value}`;
+        return `$${key.toLowerCase()}=${value}`
       })
-        .join(';');
+      .join(';')
     } else {
       return expandKeys.map(key => {
         const builtExpand = buildExpand(expands[key]);
-        return builtExpand
-               ? `${key}(${builtExpand})`
-               : key;
+        return builtExpand ? `${key}(${builtExpand})` : key;
       })
-        .join(',');
+      .join(',')
     }
   }
 }
 
 function buildTransforms(transforms) {
   // Wrap single object an array for simplified processing
-  const transformsArray = Array.isArray(transforms)
-                          ? transforms
-                          : [transforms];
+  const transformsArray = Array.isArray(transforms) ? transforms : [transforms];
 
   const transformsResult = transformsArray.reduce((result, transform) => {
     Object.keys(transform).forEach(transformKey => {
       const transformValue = transform[transformKey];
-      switch (transformKey) {
+      switch(transformKey) {
         case 'aggregate':
-          result.push(`aggregate(${buildAggregate(transformValue)})`);
+          result.push(`aggregate(${buildAggregate(transformValue)})`)
           break;
         case 'filter':
           const builtFilter = buildFilter(transformValue);
           if (builtFilter !== undefined) {
-            result.push(`filter(${buildFilter(transformValue)})`);
+            result.push(`filter(${buildFilter(transformValue)})`)
           }
           break;
         case 'groupby': // support both cases
         case 'groupBy':
-          result.push(`groupby(${buildGroupBy(transformValue)})`);
+          result.push(`groupby(${buildGroupBy(transformValue)})`)
           break;
         default:
           // TODO: support as many of the following:
           //   topcount, topsum, toppercent,
           //   bottomsum, bottomcount, bottompercent,
           //   identity, concat, expand, search, compute, isdefined
-          throw new Error(`Unsupported transform: '${transformKey}'`);
+          throw new Error(`Unsupported transform: '${transformKey}'`)
       }
-    });
+    })
 
     return result;
-  }, []);
+  }, [])
 
   return transformsResult.join('/') || undefined;
 }
 
 function buildAggregate(aggregate) {
   // Wrap single object in an array for simplified processing
-  const aggregateArray = Array.isArray(aggregate)
-                         ? aggregate
-                         : [aggregate];
+  const aggregateArray = Array.isArray(aggregate) ? aggregate : [aggregate];
 
   return aggregateArray.map(aggregateItem => {
     return Object.keys(aggregateItem).map(aggregateKey => {
@@ -276,20 +261,20 @@ function buildAggregate(aggregate) {
 
       // TODO: Are these always required?  Can/should we default them if so?
       if (aggregateValue.with === undefined) {
-        throw new Error(`'with' property required for '${aggregateKey}'`);
+        throw new Error(`'with' property required for '${aggregateKey}'`)
       }
       if (aggregateValue.as === undefined) {
-        throw new Error(`'as' property required for '${aggregateKey}'`);
+        throw new Error(`'as' property required for '${aggregateKey}'`)
       }
 
-      return `${aggregateKey} with ${aggregateValue.with} as ${aggregateValue.as}`;
-    });
-  }).join(',');
+      return `${aggregateKey} with ${aggregateValue.with} as ${aggregateValue.as}`
+    })
+  }).join(',')
 }
 
 function buildGroupBy(groupBy) {
   if (groupBy.properties === undefined) {
-    throw new Error(`'properties' property required for groupBy:'${aggregateKey}'`);
+    throw new Error(`'properties' property required for groupBy:'${aggregateKey}'`)
   }
 
   let result = `(${groupBy.properties.join(',')})`;
@@ -303,9 +288,9 @@ function buildGroupBy(groupBy) {
 
 function buildOrderBy(orderBy) {
   if (typeof(orderBy) === 'number') {
-    return orderBy;
+    return orderBy
   } else if (typeof(orderBy) === 'string') {
-    return orderBy;
+    return orderBy
   } else if (Array.isArray(orderBy)) {
     return `${orderBy.map(o => buildOrderBy(o)).join(',')}`;
   }

--- a/src/index.js
+++ b/src/index.js
@@ -101,13 +101,13 @@ function buildFilter(filters = {}, propPrefix = '') {
   } else if (typeof(filters) === 'object') {
     const filtersArray = Object.keys(filters).reduce((result, filterKey) => {
       const value = filters[filterKey];
-      const propName = propPrefix ? 
+      const propName = propPrefix ?
         (FUNCTION_REGEX.test(filterKey) ? filterKey.replace(FUNCTION_REGEX, `(${propPrefix}/$1)`) : `${propPrefix}/${filterKey}`)
         : filterKey;
 
       if (["number", "string", "boolean"].indexOf(typeof(value)) !== -1 || value instanceof Date || value === null) {
         // Simple key/value handled as equals operator
-        result.push(`${propName} eq ${handleValue(value)}`) 
+        result.push(`${propName} eq ${handleValue(value)}`)
       } else if (Array.isArray(value)) {
         const op = filterKey;
         const builtFilters = value.map(v => buildFilter(v, propPrefix)).filter(f => f !== undefined);
@@ -123,21 +123,21 @@ function buildFilter(filters = {}, propPrefix = '') {
         const operators = Object.keys(value);
         operators.forEach(op => {
           if ([...COMPARISON_OPERATORS, ...LOGICAL_OPERATORS].indexOf(op) !== -1) {
-            result.push(`${propName} ${op} ${handleValue(value[op])}`) 
+            result.push(`${propName} ${op} ${handleValue(value[op])}`)
           } else if (COLLECTION_OPERATORS.indexOf(op) !== -1) {
             const lambaParameter = propName[0].toLowerCase();
             const filter = buildFilter(value[op], lambaParameter);
-            
+
             if (filter !== undefined) {
               // Do not apply collection filter if undefined (ex. ignore `Foo: { any: {} }`)
-              result.push(`${propName}/${op}(${lambaParameter}:${filter})`) 
+              result.push(`${propName}/${op}(${lambaParameter}:${filter})`)
             }
           } else if (op === 'in') {
             // Convert `{ Prop: { in: [1,2,3] } }` to `Prop eq 1 or Prop eq 2 or Prop eq 3`
-            result.push(value[op].map(v => `${propName} eq ${handleValue(v)}`).join(' or '))
+            result.push('(' + value[op].map(v => `${propName} eq ${handleValue(v)}`).join(' or ') + ')')
           } else if (BOOLEAN_FUNCTIONS.indexOf(op) !== -1) {
             // Simple boolean functions (startswith, endswith, contains)
-            result.push(`${op}(${propName},${handleValue(value[op])})`) 
+            result.push(`${op}(${propName},${handleValue(value[op])})`)
           } else {
             // Nested property
             result.push(buildFilter(value, propName));
@@ -258,8 +258,8 @@ function buildAggregate(aggregate) {
   return aggregateArray.map(aggregateItem => {
     return Object.keys(aggregateItem).map(aggregateKey => {
       const aggregateValue = aggregateItem[aggregateKey];
-      
-      // TODO: Are these always required?  Can/should we default them if so? 
+
+      // TODO: Are these always required?  Can/should we default them if so?
       if (aggregateValue.with === undefined) {
         throw new Error(`'with' property required for '${aggregateKey}'`)
       }
@@ -267,7 +267,7 @@ function buildAggregate(aggregate) {
         throw new Error(`'as' property required for '${aggregateKey}'`)
       }
 
-      return `${aggregateKey} with ${aggregateValue.with} as ${aggregateValue.as}` 
+      return `${aggregateKey} with ${aggregateValue.with} as ${aggregateValue.as}`
     })
   }).join(',')
 }

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -36,14 +36,21 @@ describe('filter', () => {
 
     it('should convert "in" operator to "or" statement', () => {
       const filter = { SomeProp: { in: [1, 2, 3] } };
-      const expected = '?$filter=SomeProp eq 1 or SomeProp eq 2 or SomeProp eq 3'
+      const expected = '?$filter=(SomeProp eq 1 or SomeProp eq 2 or SomeProp eq 3)'
       const actual = buildQuery({ filter });
       expect(actual).toEqual(expected);
     });
 
     it('should convert "in" operator to "or" statement and wrap in parens when using an array', () => {
       const filter = [{ SomeProp: { in: [1, 2, 3] } }, { AnotherProp: 4 }];
-      const expected = '?$filter=(SomeProp eq 1 or SomeProp eq 2 or SomeProp eq 3) and (AnotherProp eq 4)'
+      const expected = '?$filter=((SomeProp eq 1 or SomeProp eq 2 or SomeProp eq 3)) and (AnotherProp eq 4)'
+      const actual = buildQuery({ filter });
+      expect(actual).toEqual(expected);
+    });
+
+    it('should convert "in" operator to "or" statement and wrap in parens', () => {
+      const filter = { SomeProp: { in: [1, 2, 3] } };
+      const expected = '?$filter=(SomeProp eq 1 or SomeProp eq 2 or SomeProp eq 3)'
       const actual = buildQuery({ filter });
       expect(actual).toEqual(expected);
     });
@@ -77,7 +84,7 @@ describe('filter', () => {
       const actual = buildQuery({ filter });
       expect(actual).toEqual(expected);
     });
-    
+
     it('should handle simple logical operators (and, or, etc) as an object (no parens)', () => {
       const filter = { and: { SomeProp: 1 , AnotherProp: 2 } }
       const expected = "?$filter=SomeProp eq 1 and AnotherProp eq 2"
@@ -98,7 +105,7 @@ describe('filter', () => {
       const actual = buildQuery({ filter });
       expect(actual).toEqual(expected);
     });
-    
+
     it('should ignore implied logical operator with no filters', () => {
       const filter = []
       const expected = ""
@@ -156,8 +163,8 @@ describe('filter', () => {
     });
 
     it('should handle implied logical operator on a single property', () => {
-      const startDate = new Date(Date.UTC(2017, 0, 1)) 
-      const endDate = new Date(Date.UTC(2017, 2, 1)) 
+      const startDate = new Date(Date.UTC(2017, 0, 1))
+      const endDate = new Date(Date.UTC(2017, 2, 1))
       const filter = { DateProp: { ge: startDate, le: endDate } }
       const expected = "?$filter=DateProp ge 2017-01-01T00:00:00.000Z and DateProp le 2017-03-01T00:00:00.000Z"
       const actual = buildQuery({ filter });
@@ -180,7 +187,7 @@ describe('filter', () => {
     it('should ignore collection operator with an empty array of filters', () => {
       const filter = {
         Tasks: {
-          any: [] 
+          any: []
         }
       }
       const expected = ""
@@ -242,7 +249,7 @@ describe('filter', () => {
       const actual = buildQuery({ filter });
       expect(actual).toEqual(expected);
     });
-    
+
     it('should handle collection operator with nested property', () => {
       const filter = {
         Tasks: {
@@ -384,7 +391,7 @@ describe('transform', () => {
     const actual = buildQuery({ transform });
     expect(actual).toEqual(expected);
   });
-  
+
   it('multiple aggregations with same property as array', () => {
     const transform = [{
       aggregate: [{
@@ -417,7 +424,7 @@ describe('transform', () => {
 
   it('should omit/ignore undefined filters', () => {
     const transform = { filter: undefined };
-    const expected = '' 
+    const expected = ''
     const actual = buildQuery({ transform });
     expect(actual).toEqual(expected);
   });
@@ -498,7 +505,7 @@ describe('transform', () => {
     const actual = buildQuery({ transform });
     expect(actual).toEqual(expected);
   });
-  
+
   it('group by with filter before and after as array', () => {
     const transform = [{
       filter: {
@@ -559,7 +566,7 @@ describe('orderBy', () => {
     const actual = buildQuery({ orderBy });
     expect(actual).toEqual(expected);
   });
-  
+
   it('should support ordering a nested property within an expand', () => {
     const query = {
       expand: {
@@ -647,7 +654,7 @@ describe('count', () => {
     const actual = buildQuery({ count });
     expect(actual).toEqual(expected);
   });
-  
+
   it('should allow groupby when querying for only count', () => {
     const count = {};
     const transform = [{
@@ -733,7 +740,7 @@ describe('expand', () => {
     const actual = buildQuery({ expand });
     expect(actual).toEqual(expected);
   });
-  
+
   it('should allow multiple expands with objects', () => {
     const expand = { Friends: {}, One: { orderBy: 'Two' } };
     const expected = '?$expand=Friends,One($orderby=Two)';

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -41,23 +41,16 @@ describe('filter', () => {
       expect(actual).toEqual(expected);
     });
 
-    it('should convert "in" operator to "or" statement and wrap in parens when using an array', () => {
+    it('should convert "in" operator to "or" statement and wrap in parens', () => {
+      const filter = {SomeNames: {contains: "Bob", in: ["Peter Newman", "Bob Ross", "Bobby Parker", "Mike Bobson"]}};
+      const expected = '?$filter=contains(SomeNames,\'Bob\') and (SomeNames eq \'Peter Newman\' or SomeNames eq \'Bob Ross\' or SomeNames eq \'Bobby Parker\' or SomeNames eq \'Mike Bobson\')'
+      const actual = buildQuery({ filter });
+      expect(actual).toEqual(expected);
+    });
+
+    it('should convert "in" operator to "or" statement and wrap in double parens when using an array', () => {
       const filter = [{ SomeProp: { in: [1, 2, 3] } }, { AnotherProp: 4 }];
       const expected = '?$filter=((SomeProp eq 1 or SomeProp eq 2 or SomeProp eq 3)) and (AnotherProp eq 4)'
-      const actual = buildQuery({ filter });
-      expect(actual).toEqual(expected);
-    });
-
-    it('should convert "in" operator to "or" statement and wrap in parens', () => {
-      const filter = { SomeProp: { in: [1, 2, 3] } };
-      const expected = '?$filter=(SomeProp eq 1 or SomeProp eq 2 or SomeProp eq 3)'
-      const actual = buildQuery({ filter });
-      expect(actual).toEqual(expected);
-    });
-
-    it('should convert "in" operator to "or" statement and wrap in parens', () => {
-      const filter = { SomeProp: 1, AnotherProp: { in: [2, 3,4 ], contains: 5 }};
-      const expected = '?$filter=SomeProp eq 1 and (AnotherProp eq 2 or AnotherProp eq 3 or AnotherProp eq 4) and contains(AnotherProp,5)'
       const actual = buildQuery({ filter });
       expect(actual).toEqual(expected);
     });

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -55,6 +55,13 @@ describe('filter', () => {
       expect(actual).toEqual(expected);
     });
 
+    it('should convert "in" operator to "or" statement and wrap in parens', () => {
+      const filter = { SomeProp: 1, AnotherProp: { in: [2, 3,4 ], contains: 5 }};
+      const expected = '?$filter=SomeProp eq 1 and (AnotherProp eq 2 or AnotherProp eq 3 or AnotherProp eq 4) and contains(AnotherProp,5)'
+      const actual = buildQuery({ filter });
+      expect(actual).toEqual(expected);
+    });
+
     it('should ignore/omit filter if set to undefined', () => {
       const filter = { IgnoreProp: undefined };
       const expected = '';


### PR DESCRIPTION
This fixes #13, but an in operator whit an implied and will result in double paranthesis

```
[{
    SomeProp: {
         in: [1, 2, 3]
    }
},
{
    AnotherProp: 4
}];
```

```
?$filter=((SomeProp eq 1 or SomeProp eq 2 or SomeProp eq 3)) and (AnotherProp eq 4)
```