### PR TITLE
Data Types: add GUID support

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ import buildQuery from 'odata-query'
 
 const query = buildQuery({...})
 fetch(`http://localhost${query}`)
-``` 
+```
 where the query object syntax for `{...}` is defined below.  There is also [react-odata](https://github.com/techniq/react-odata) which utilizies this library for a declarative React component.
 
 ## Usage
@@ -57,7 +57,7 @@ See [tests](src/index.test.js) for examples as well
 - [Actions](#actions)
 - [Functions](#functions-1)
 - [Transforms](#transforms)
-  
+
 ### Filtering
 ```js
 buildQuery({ filter: {...} })
@@ -90,8 +90,8 @@ buildQuery({ filter })
 ##### Implied `and` with multiple comparison operators for a single property
 Useful to perform a `between` query on a `Date` property
 ```js
-const startDate = new Date(Date.UTC(2017, 0, 1)) 
-const endDate = new Date(Date.UTC(2017, 2, 1)) 
+const startDate = new Date(Date.UTC(2017, 0, 1))
+const endDate = new Date(Date.UTC(2017, 2, 1))
 const filter = { DateProp: { ge: startDate, le: endDate } }
 buildQuery({ filter })
 => "?$filter=DateProp ge 2017-01-01T00:00:00Z and DateProp le 2017-03-01T00:00:00Z"
@@ -106,7 +106,7 @@ const filter = {
     'startswith(Name, "foo")'
   ]
 };
-    
+
 buildQuery({ filter })
 => '?$filter=SomeProp eq 1 and AnotherProp eq 2 and startswith(Name, "foo")'
 ```
@@ -126,7 +126,7 @@ const filter = {
     }
   }
 };
-    
+
 buildQuery({ filter })
 => '?$filter=ItemsProp/any(i:i/SomeProp eq 1 and i/AnotherProp eq 2)'
 ```
@@ -141,7 +141,7 @@ const filter = {
     ]
   }
 };
-    
+
 buildQuery({ filter })
 => '?$filter=ItemsProp/any(i:i/SomeProp eq 1 and i/AnotherProp eq 2)'
 ```
@@ -158,7 +158,7 @@ const filter = {
     }
   }
 };
-    
+
 buildQuery({ filter })
 => '?$filter=ItemsProp/any(i:(i/SomeProp eq 1 or i/AnotherProp eq 2)'
 ```
@@ -204,7 +204,14 @@ buildQuery({ filter })
 ```
 
 #### Data types
-Coming soon
+GUID:
+```js
+const filter = { "someProp": { eq: { cast: 'guid', value: 'cd5977c2-4a64-42de-b2fc-7fe4707c65cd' } };
+buildQuery({ filter })
+=> "?$filter=someProp eq cd5977c2-4a64-42de-b2fc-7fe4707c65cd"
+```
+
+Other types coming soon
 
 #### Search
 ```js

--- a/src/index.js
+++ b/src/index.js
@@ -232,8 +232,14 @@ function handleValue(value) {
     return `'${escapeIllegalChars(value)}'`;
   } else if (value instanceof Date) {
     return value.toISOString();
+  } else if (value instanceof Number) {
+    return value;
   } else {
     // TODO: Figure out how best to specify types.  See: https://github.com/devnixs/ODataAngularResources/blob/master/src/odatavalue.js
+    switch (value && value.cast) {
+      case 'guid':
+      return value.value;
+    }
     return value;
   }
 }

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -88,7 +88,7 @@ describe('filter', () => {
       const actual = buildQuery({ filter });
       expect(actual).toEqual(expected);
     });
-    
+
     it.skip('should handle nested properties on the same property (implicit "and")', () => {
       const filter = {
         SomeProp: {
@@ -218,12 +218,12 @@ describe('filter', () => {
       const filter = {
         or: [
           { Prop1: 1 },
-          { 
+          {
             and: {
               Prop2: 2,
               Prop3: 3
             }
-        } 
+        }
         ]
       };
       const expected = "?$filter=((Prop1 eq 1) or (Prop2 eq 2 and Prop3 eq 3))";
@@ -272,7 +272,7 @@ describe('filter', () => {
             {
               Prop4: {
                 NestedProp4: {
-                  DeeplyNestedProp4:4 
+                  DeeplyNestedProp4:4
                 }
               }
             }
@@ -301,7 +301,7 @@ describe('filter', () => {
               }
             ]
           }
-          
+
       };
       const expected = "?$filter=Prop1/NestedProp1 eq 1 and (Prop2/NestedProp2/DeeplyNestedProp2 eq 2 and Prop2/NestedProp3 ne null) or (Prop2/NestedProp4/DeeplyNestedProp4 eq 4)";
       const actual = buildQuery({ filter });
@@ -335,7 +335,7 @@ describe('filter', () => {
             NestedProp1: 1
           },
           or: [
-            { 
+            {
               Prop2: {
                 NestedProp2: {
                   DeeplyNestedProp2: 2
@@ -365,7 +365,7 @@ describe('filter', () => {
             NestedProp1: 1
           },
           or: [
-            { 
+            {
               Prop2: {
                 and: {
                   NestedProp2: {
@@ -580,6 +580,13 @@ describe('filter', () => {
       const expected = '?$filter=DateProp eq 2017-03-30T07:30:00.000Z';
       const actual = buildQuery({ filter });
       expect(actual).toEqual(expected);
+    });
+
+    it('should handle GUID values', () => {
+        const filter = { "someProp": { eq: { cast: 'guid', value: 'cd5977c2-4a64-42de-b2fc-7fe4707c65cd' } } };
+        const expected = '?$filter=someProp eq cd5977c2-4a64-42de-b2fc-7fe4707c65cd';
+        const actual = buildQuery({ filter });
+        expect(actual).toEqual(expected);
     });
   });
 


### PR DESCRIPTION
I've added a convention, passing the value in the form of `{ cast: 'type', value: 'actualValue' }`, you can specify its custom type.
Added support for GUID.
More types can easily be added like this.