### PR TITLE
Support formats

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -25,7 +25,8 @@ export default function({
   count,
   expand,
   action,
-  func
+  func,
+  format
 } = {}) {
   let path = '';
   const params = {};
@@ -118,6 +119,10 @@ export default function({
 
   if (orderBy) {
     params.$orderby = buildOrderBy(orderBy);
+  }
+
+  if(format) {
+    params.$format = format;
   }
 
   return buildUrl(path, params);

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -1246,3 +1246,12 @@ describe('function', () => {
     expect(actual).toEqual(expected);
   });
 });
+
+describe('format', () => {
+  it('should support format', () => {
+    const format = 'json';
+    const expected = '?$format=json';
+    const actual = buildQuery({ format });
+    expect(actual).toEqual(expected);
+  })
+})


### PR DESCRIPTION
Supports format on the query.

```
const format = 'json';
buildQuery({ format });
// ?$format=json
```