### PR TITLE
Add basic support for 'not' logical operator

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -166,9 +166,15 @@ function buildFilter(filters = {}, propPrefix = '') {
           .map(f => (LOGICAL_OPERATORS.indexOf(op) !== -1 ? `(${f})` : f));
         if (builtFilters.length) {
           if (LOGICAL_OPERATORS.indexOf(op) !== -1) {
-            result.push(parseNot(op, builtFilters, true));
+            if (builtFilters.length) {
+              if (op === 'not') {
+                result.push(parseNot(op, builtFilters));
+              }else{
+                result.push(`(${builtFilters.join(` ${op} `)})`)
+              }
+              }
           } else {
-            result.push(builtFilters.join(` ${op} `));
+                result.push(builtFilters.join(` ${op} `));
           }
         }
       } else if (LOGICAL_OPERATORS.indexOf(propName) !== -1) {
@@ -177,7 +183,12 @@ function buildFilter(filters = {}, propPrefix = '') {
           buildFilter({ [valueKey]: value[valueKey] })
         );
         if (builtFilters.length) {
-          result.push(parseNot(op, builtFilters, false));
+          if (op === 'not') {
+            result.push(parseNot(op, builtFilters));
+
+          }else{
+            result.push(`${builtFilters.join(` ${op} `)}`)
+          }
         }
       } else if (value instanceof Object) {
         if ('type' in value) {
@@ -438,8 +449,7 @@ function buildUrl(path, params) {
   }
 }
 
-function parseNot(op, builtFilters, parentheses) {
-  if (op === 'not') {
+function parseNot(op, builtFilters) {
     if (builtFilters.length > 1) {
       return `not( ${builtFilters.join(' and ')})`
     } else {
@@ -451,11 +461,4 @@ function parseNot(op, builtFilters, parentheses) {
         }
       })
     }
-  } else {
-    if (parentheses) {
-      return `(${builtFilters.join(` ${op} `)})`;
-    } else {
-      return `${builtFilters.join(` ${op} `)}`;
-    }
-  }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -166,9 +166,9 @@ function buildFilter(filters = {}, propPrefix = '') {
           .map(f => (LOGICAL_OPERATORS.indexOf(op) !== -1 ? `(${f})` : f));
         if (builtFilters.length) {
           if (LOGICAL_OPERATORS.indexOf(op) !== -1) {
-            result.push(`(${builtFilters.join(` ${op} `)})`);
+            result.push(parseNot(op, builtFilters, true));
           } else {
-            result.push(`${builtFilters.join(` ${op} `)}`);
+            result.push(builtFilters.join(` ${op} `));
           }
         }
       } else if (LOGICAL_OPERATORS.indexOf(propName) !== -1) {
@@ -177,7 +177,7 @@ function buildFilter(filters = {}, propPrefix = '') {
           buildFilter({ [valueKey]: value[valueKey] })
         );
         if (builtFilters.length) {
-          result.push(builtFilters.join(` ${op} `));
+          result.push(parseNot(op, builtFilters, false));
         }
       } else if (value instanceof Object) {
         if ('type' in value) {
@@ -435,5 +435,27 @@ function buildUrl(path, params) {
     );
   } else {
     return path;
+  }
+}
+
+function parseNot(op, builtFilters, parentheses) {
+  if (op === 'not') {
+    if (builtFilters.length > 1) {
+      return `not( ${builtFilters.join(' and ')})`
+    } else {
+      return builtFilters.map(filter => {
+        if (filter.charAt(0) === '(') {
+          return '(not '.concat(filter.substr(1))
+        } else {
+          return 'not '.concat(filter)
+        }
+      })
+    }
+  } else {
+    if (parentheses) {
+      return `(${builtFilters.join(` ${op} `)})`;
+    } else {
+      return `${builtFilters.join(` ${op} `)}`;
+    }
   }
 }

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -119,6 +119,34 @@ describe('filter', () => {
   });
 
   describe('logical operators', () => {
+    it('should handle simple logical operators (not) as an object', () => {
+      const filter = {and:[ {not: { FooProp: {'startswith': 'foo'}}},{not: { BarProp: {'startswith': 'bar'}}}, { FooBarProp: {'startswith': 'foobar'}}]};
+      const expected = '?$filter=((not startswith(FooProp,\'foo\')) and (not startswith(BarProp,\'bar\')) and (startswith(FooBarProp,\'foobar\')))';
+      const actual = buildQuery({ filter });
+      expect(actual).toEqual(expected);
+    });
+
+    it('should handle logical operators (not) as an object', () => {
+      const filter = {and:[ {not: { FooProp: {'startswith': 'foo'}, BarProp: {'startswith': 'bar'}}}, { FooBarProp: {'startswith': 'bar'}}]};
+      const expected = '?$filter=((not( startswith(FooProp,\'foo\') and startswith(BarProp,\'bar\'))) and (startswith(FooBarProp,\'bar\')))';
+      const actual = buildQuery({ filter });
+      expect(actual).toEqual(expected);
+    });
+
+    it('should handle simple logical operators (not) as an array', () => {
+      const filter =  {not: [ {FooProp: {'startswith': 'foo'}},{BarProp: {'startswith': 'bar'}}] };
+      const expected = '?$filter=not( (startswith(FooProp,\'foo\')) and (startswith(BarProp,\'bar\')))';
+      const actual = buildQuery({ filter });
+      expect(actual).toEqual(expected);
+    });
+
+    it('should handle logical operators (not) as an array', () => {
+      const filter = {or:[ {not: [ {FooProp: {'startswith': 'foo'}}, {BarProp: {'startswith': 'bar'}}]}]};
+      const expected = '?$filter=((not( (startswith(FooProp,\'foo\')) and (startswith(BarProp,\'bar\')))))';
+      const actual = buildQuery({ filter });
+      expect(actual).toEqual(expected);
+    });
+    
     it('should handle simple logical operators (and, or, etc) as an array', () => {
       const filter = { and: [{ SomeProp: 1 }, { AnotherProp: 2 }] };
       const expected = '?$filter=((SomeProp eq 1) and (AnotherProp eq 2))';


### PR DESCRIPTION
'not' can be specified as an as the key for an array or an object to prepend 'not' to a filter:
e.g. `filter:{not: {SomeProp:{'startswith': 'bar'}}}` generates `?$filter=not startswith(SomeProp,'foo')`