### PR TITLE
Adding commonjs module support

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "author": "Sean Lynch <techniq35@gmail.com>",
   "license": "MIT",
   "repository": "techniq/odata-query",
-  "main": "dist/index.js",
+  "main": "dist/commonjs/index.js",
+  "module": "dist/esm/index.js",
   "typings": "dist/index.d.ts",
   "files": [
     "dist"
@@ -19,7 +20,7 @@
   },
   "scripts": {
     "prebuild": "rimraf dist",
-    "build": "tsc",
+    "build": "tsc -p tsconfig.cjs.json & tsc -p tsconfig.esm.json & tsc -p tsconfig.dts.json",
     "test": "jest",
     "test-watch": "jest --watchAll",
     "preversion": "npm run build"

--- a/tsconfig.cjs.json
+++ b/tsconfig.cjs.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "outDir": "dist/commonjs"
+  }
+}

--- a/tsconfig.dts.json
+++ b/tsconfig.dts.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "outDir": "dist"
+  }
+}

--- a/tsconfig.esm.json
+++ b/tsconfig.esm.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "esnext",
+    "outDir": "dist/esm"
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,11 +2,9 @@
   "include": ["src", "types"],
   "compilerOptions": {
     "target": "es5",
-    "module": "esnext",
     "lib": ["dom", "esnext"],
     "importHelpers": true,
-    "declaration": true,
-    "sourceMap": true,
+    "declaration": false,
     "rootDir": "./src",
     "strict": true,
     "noImplicitAny": true,
@@ -27,6 +25,5 @@
     "jsx": "react",
     "esModuleInterop": true,
     "typeRoots": ["./node_modules/@types/"],
-    "outDir": "dist/"
   }
 }


### PR DESCRIPTION
Earlier only esm modules were generated, which does not work with projects with commonjs module system. Therefore, this PR adds support for generating commonjs module.

Details: 
- Added 3 new tsconfig files that inherits from the base.
- Changed the build script so that is supports generating commonjs
  module along with esm.
- Also corrected the main and module entries in package.json

@techniq Can you review the changes?