### PR TITLE
changed tslib from a dev dependency to a dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,12 +10,14 @@
   "files": [
     "dist"
   ],
+  "dependencies": {
+    "tslib": "^1.10.0"
+  },
   "devDependencies": {
     "@types/jest": "^24.0.15",
     "jest": "^24.8.0",
     "rimraf": "^2.6.3",
     "ts-jest": "^24.0.2",
-    "tslib": "^1.10.0",
     "typescript": "^3.5.2"
   },
   "scripts": {


### PR DESCRIPTION
Addresses #52 

Moves [tslib](https://www.npmjs.com/package/tslib) to a dependency so a non typescript project does not need to manually install it along with this package.