### PR TITLE
refactor: preliminary support for 'in' operator

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,14 @@ buildQuery({ filter })
 ```
 Supported operators: `eq`, `ne`, `gt`, `ge`, `lt`, `le`, `in`
 
+Using the `in` operator is also similar to the previous example.
+
+```js
+const filter = { PropName: { in: [1, 2, 3] } };
+buildQuery({ filter })
+=> '?$filter=PropName in (1,2,3)'
+```
+
 #### Logical operators
 ##### Implied `and` with an array of objects
 ```js

--- a/src/index.ts
+++ b/src/index.ts
@@ -254,21 +254,14 @@ function buildFilter(filters: Filter = {}, propPrefix = ''): string {
                   if (collectionClause) { result.push(collectionClause); }
                 } else if (op === 'in') {
                   const resultingValues = Array.isArray(value[op])
-                    ? // Convert `{ Prop: { in: [1,2,3] } }` to `(Prop eq 1 or Prop eq 2 or Prop eq 3)`
-                    value[op]
-                    : // Convert `{ Prop: { in: [{type: type, value: 1},{type: type, value: 2},{type: type, value: 3}] } }`
-                    // to `(Prop eq 1 or Prop eq 2 or Prop eq 3)`
-                    value[op].value.map((typedValue: any) => ({
+                    ? value[op]
+                    : value[op].value.map((typedValue: any) => ({
                       type: value[op].type,
                       value: typedValue,
                     }));
 
                   result.push(
-                    '(' +
-                    resultingValues
-                      .map((v: any) => `${propName} eq ${handleValue(v)}`)
-                      .join(' or ') +
-                    ')'
+                    propName + ' in (' + resultingValues.map((v: any) => handleValue(v)).join(',') + ')'
                   );
                 } else if (BOOLEAN_FUNCTIONS.indexOf(op) !== -1) {
                   // Simple boolean functions (startswith, endswith, contains)

--- a/src/index.ts
+++ b/src/index.ts
@@ -499,10 +499,5 @@ function buildUrl(path: string, params: PlainObject): string {
 }
 
 function parseNot(builtFilters: string[]): string {
-  if (builtFilters.length > 1) {
-    return `not( ${builtFilters.join(' and ')})`;
-  } else {
-    const filter = builtFilters[0] as string;
-    return filter.charAt(0) === '(' ? `(not ${filter.substr(1)}` : `not ${filter}`;
-  }
+  return `not(${builtFilters.join(' and ')})`;
 }

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -42,7 +42,7 @@ describe('filter', () => {
     it('should convert "in" operator to "or" statement', () => {
       const filter = { SomeProp: { in: [1, 2, 3] } };
       const expected =
-        '?$filter=(SomeProp eq 1 or SomeProp eq 2 or SomeProp eq 3)';
+        '?$filter=SomeProp in (1,2,3)';
       const actual = buildQuery({ filter });
       expect(actual).toEqual(expected);
     });
@@ -55,7 +55,7 @@ describe('filter', () => {
         },
       };
       const expected =
-        "?$filter=contains(SomeNames,'Bob') and (SomeNames eq 'Peter Newman' or SomeNames eq 'Bob Ross' or SomeNames eq 'Bobby Parker' or SomeNames eq 'Mike Bobson')";
+        "?$filter=contains(SomeNames,'Bob') and SomeNames in ('Peter Newman','Bob Ross','Bobby Parker','Mike Bobson')";
       const actual = buildQuery({ filter });
       expect(actual).toEqual(expected);
     });
@@ -63,7 +63,7 @@ describe('filter', () => {
     it('converting "in" operator to "or" statement also works when using in an array', () => {
       const filter = [{ SomeProp: { in: [1, 2, 3] }, AnotherProp: 4 }];
       const expected =
-        '?$filter=(SomeProp eq 1 or SomeProp eq 2 or SomeProp eq 3) and AnotherProp eq 4';
+        '?$filter=SomeProp in (1,2,3) and AnotherProp eq 4';
       const actual = buildQuery({ filter });
       expect(actual).toEqual(expected);
     });
@@ -716,7 +716,7 @@ describe('filter', () => {
         },
       };
       const expected =
-        '?$filter=(someProp eq cd5977c2-4a64-42de-b2fc-7fe4707c65cd or someProp eq cd5977c2-4a64-42de-b2fc-7fe4707c65ce)';
+        '?$filter=someProp in (cd5977c2-4a64-42de-b2fc-7fe4707c65cd,cd5977c2-4a64-42de-b2fc-7fe4707c65ce)';
       const actual = buildQuery({ filter });
       expect(actual).toEqual(expected);
     });

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -39,7 +39,7 @@ describe('filter', () => {
       expect(actual).toEqual(expected);
     });
 
-    it('should convert "in" operator to "or" statement', () => {
+    it('should allow "in" operator', () => {
       const filter = { SomeProp: { in: [1, 2, 3] } };
       const expected =
         '?$filter=SomeProp in (1,2,3)';
@@ -47,7 +47,7 @@ describe('filter', () => {
       expect(actual).toEqual(expected);
     });
 
-    it('should convert "in" operator to "or" statement and wrap in parens', () => {
+    it('should allow "in" operator in combination with other conditions', () => {
       const filter = {
         SomeNames: {
           contains: 'Bob',
@@ -60,10 +60,18 @@ describe('filter', () => {
       expect(actual).toEqual(expected);
     });
 
-    it('converting "in" operator to "or" statement also works when using in an array', () => {
+    it('allows "in" operator when using in an array', () => {
       const filter = [{ SomeProp: { in: [1, 2, 3] }, AnotherProp: 4 }];
       const expected =
         '?$filter=SomeProp in (1,2,3) and AnotherProp eq 4';
+      const actual = buildQuery({ filter });
+      expect(actual).toEqual(expected);
+    });
+
+    it('allows "in" operator in negated case', () => {
+      const filter = { not: { SomeProp: { in: [1, 2, 3] } } };
+      const expected =
+        '?$filter=not(SomeProp in (1,2,3))';
       const actual = buildQuery({ filter });
       expect(actual).toEqual(expected);
     });
@@ -128,7 +136,7 @@ describe('filter', () => {
         ],
       };
       const expected =
-        "?$filter=((not startswith(FooProp,'foo')) and (not startswith(BarProp,'bar')) and (startswith(FooBarProp,'foobar')))";
+        "?$filter=((not(startswith(FooProp,'foo'))) and (not(startswith(BarProp,'bar'))) and (startswith(FooBarProp,'foobar')))";
       const actual = buildQuery({ filter });
       expect(actual).toEqual(expected);
     });
@@ -146,7 +154,7 @@ describe('filter', () => {
         ],
       };
       const expected =
-        "?$filter=((not( startswith(FooProp,'foo') and startswith(BarProp,'bar'))) and (startswith(FooBarProp,'bar')))";
+        "?$filter=((not(startswith(FooProp,'foo') and startswith(BarProp,'bar'))) and (startswith(FooBarProp,'bar')))";
       const actual = buildQuery({ filter });
       expect(actual).toEqual(expected);
     });
@@ -156,10 +164,11 @@ describe('filter', () => {
         not: [
           { FooProp: { startswith: 'foo' } },
           { BarProp: { startswith: 'bar' } },
+          { FizProp: { in: [1, 2, 3]     } },
         ],
       };
       const expected =
-        "?$filter=not( (startswith(FooProp,'foo')) and (startswith(BarProp,'bar')))";
+        "?$filter=not((startswith(FooProp,'foo')) and (startswith(BarProp,'bar')) and (FizProp in (1,2,3)))";
       const actual = buildQuery({ filter });
       expect(actual).toEqual(expected);
     });
@@ -171,12 +180,13 @@ describe('filter', () => {
             not: [
               { FooProp: { startswith: 'foo' } },
               { BarProp: { startswith: 'bar' } },
+              { FizProp: { in: [1, 2, 3]     } },
             ],
           },
         ],
       };
       const expected =
-        "?$filter=((not( (startswith(FooProp,'foo')) and (startswith(BarProp,'bar')))))";
+        "?$filter=((not((startswith(FooProp,'foo')) and (startswith(BarProp,'bar')) and (FizProp in (1,2,3)))))";
       const actual = buildQuery({ filter });
       expect(actual).toEqual(expected);
     });


### PR DESCRIPTION
Instead of exploding `{ SomeProp: { in: [1, 2, 3] } }` to `(SomeProp eq 1 or SomeProp eq 2 or SomeProp eq 3)`, it is converted to odata in opertor: `SomeProp in (1,2,3)`.

The negated case (`not in`) like `{ not: { SomeProp: { in: [1, 2, 3] } } }` is translated to `not(SomeProp in (1,2,3))`.
Closes #22