### PR TITLE
[FIX] Allow zero in query values

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -494,8 +494,9 @@ function buildUrl(path: string, params: PlainObject): string {
   // This can be refactored using URL API. But IE does not support it.
   const queries: string[] = [];
   for (const key of Object.getOwnPropertyNames(params)) {
-    if (params[key]) {
-      queries.push(`${key}=${params[key]}`);
+    const value = params[key]; 
+    if (value === 0 || !!value) {
+      queries.push(`${key}=${value}`);
     }
   }
   return queries.length ? `${path}?${queries.join('&')}` : path;

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1317,7 +1317,6 @@ describe('pagination', () => {
     const actual = buildQuery({ top, skip });
     expect(actual).toEqual(expected);
   });
-
 });
 
 describe('expand', () => {

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1295,6 +1295,29 @@ describe('pagination', () => {
     const actual = buildQuery({ top, skip });
     expect(actual).toEqual(expected);
   });
+
+  it('should support skipping zero items', () => {
+    const skip = 0;
+    const expected = '?$skip=0';
+    const actual = buildQuery({ skip });
+    expect(actual).toEqual(expected);
+  });
+
+  it('should support limiting to zero items', () => {
+    const top = 0;
+    const expected = '?$top=0';
+    const actual = buildQuery({ top });
+    expect(actual).toEqual(expected);
+  });
+
+  it('should support limiting and skipping zero items', () => {
+    const top = 0;
+    const skip = 0;
+    const expected = '?$top=0&$skip=0';
+    const actual = buildQuery({ top, skip });
+    expect(actual).toEqual(expected);
+  });
+
 });
 
 describe('expand', () => {


### PR DESCRIPTION
Resolves #66
- Allow zero in query values (now $top=0 and $skip=0 works)
- Add some tests