### PR TITLE
Added support for any and all queries on simple string collections.

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -294,18 +294,30 @@ function buildFilter(filters: Filter = {}, propPrefix = ''): string {
     return filterExpr;
   }
 
-  function buildCollectionClause(lambdaParameter: string, value: any, op: string, propName: string) {
-    let clause = "";
-    if (value) {
-      // normalize {any:[{prop1: 1}, {prop2: 1}]} --> {any:{prop1: 1, prop2: 1}}; same for 'all'
-      const filter = buildFilterCore(
-        Array.isArray(value)
-          ? value.reduce((acc, item) => ({ ...acc, ...item }), {})
-          : value, lambdaParameter);
-      clause = `${propName}/${op}(${filter ? `${lambdaParameter}:${filter}` : ""})`;
-    }
-    return clause;
-  }
+	function buildCollectionClause(lambdaParameter: string, value: any, op: string, propName: string) {
+		let clause = '';
+
+		if (typeof value === 'string' || value instanceof String) {
+			clause = getStringCollectionClause(lambdaParameter, value, op, propName);
+
+		} else if (value) {
+			// normalize {any:[{prop1: 1}, {prop2: 1}]} --> {any:{prop1: 1, prop2: 1}}; same for 'all'
+			const filter = buildFilterCore(
+				Array.isArray(value)
+					? value.reduce((acc, item) => ({ ...acc, ...item }), {})
+					: value, lambdaParameter);
+			clause = `${propName}/${op}(${filter ? `${lambdaParameter}:${filter}` : ''})`;
+		}
+		return clause;
+	}
+}
+
+function getStringCollectionClause(lambdaParameter: string, value: any, collectionOperator: string, propName: string) {
+	let clause = '';
+	const conditionOperator = collectionOperator == 'all' ? 'ne' : 'eq';
+	clause = `${propName}/${collectionOperator}(${lambdaParameter}: ${lambdaParameter} ${conditionOperator} '${value}')`
+
+	return clause;
 }
 
 function escapeIllegalChars(string: string) {

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -650,6 +650,28 @@ describe('filter', () => {
       const actual = buildQuery({ filter });
       expect(actual).toEqual(expected);
     });
+
+    it('should handle collection operator over simple string collection with any', () => {
+      const filter = {
+        MacAddress: {
+          any: "3C:4A:92:F1:98:E2"
+        }
+      };      
+      const expected = "?$filter=MacAddress/any(macaddress: macaddress eq '3C:4A:92:F1:98:E2')";
+      const actual = buildQuery({ filter });
+      expect(actual).toEqual(expected);
+    })
+
+    it('should handle collection operator over simple string collection with all', () => {
+      const filter = {
+        MacAddress: {
+          all: "3C:4A:92:F1:98:E2"
+        }
+      };      
+      const expected = "?$filter=MacAddress/all(macaddress: macaddress ne '3C:4A:92:F1:98:E2')";
+      const actual = buildQuery({ filter });
+      expect(actual).toEqual(expected);
+    })
   });
 
   describe('data types', () => {


### PR DESCRIPTION
The OData specification supports querying simple collections using the any/all operators. 

One such example can be seen [here](https://docs.microsoft.com/en-us/azure/search/search-query-odata-collection-operators#examples).

I found that it was not possible to generate such a filter using odata-query. This PR is an attempt to remedy the string collection case in particular. Similar queries should also be allowed against simple numeric collections. If you'd like me to work out a PR for that case, I may have time to.

Please let me know what revisions would be necessary.

Thank you for your hard work on odata-query.
