### PR TITLE
Add ability to use all filters on the item itself with collection operators (any / all)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -86,7 +86,7 @@ export type QueryOptions<T> = ExpandOptions<T> & {
   aliases: Alias[];
 }
 
-export const ITEM_ROOT = '__item';
+export const ITEM_ROOT = "";
 
 export default function <T>({
   select: $select,
@@ -188,9 +188,9 @@ function buildFilter(filters: Filter = {}, propPrefix = ''): string {
             if (filterKey === ITEM_ROOT) {
               propName = propPrefix;
             } else if (INDEXOF_REGEX.test(filterKey)) {
-              propName = filterKey.replace(INDEXOF_REGEX, `(${propPrefix}/$1)`);
+              propName = filterKey.replace(INDEXOF_REGEX, (_,$1)=>$1.trim() === ITEM_ROOT ? `(${propPrefix})` : `(${propPrefix}/${$1.trim()})`);
             } else if (FUNCTION_REGEX.test(filterKey)) {
-              propName = filterKey.replace(FUNCTION_REGEX, `(${propPrefix}/$1)`);
+              propName = filterKey.replace(FUNCTION_REGEX, (_,$1)=>$1.trim() === ITEM_ROOT ? `(${propPrefix})` : `(${propPrefix}/${$1.trim()})`);
             } else {
               propName = `${propPrefix}/${filterKey}`;
             }

--- a/src/index.ts
+++ b/src/index.ts
@@ -83,8 +83,10 @@ export type QueryOptions<T> = ExpandOptions<T> & {
   action: string;
   func: string | { [functionName: string]: { [parameterName: string]: any } };
   format: string;
-  aliases: Alias[]; 
+  aliases: Alias[];
 }
+
+export const ITEM_ROOT = '__item';
 
 export default function <T>({
   select: $select,
@@ -183,7 +185,9 @@ function buildFilter(filters: Filter = {}, propPrefix = ''): string {
           const value = (filter as any)[filterKey];
           let propName = '';
           if (propPrefix) {
-            if (INDEXOF_REGEX.test(filterKey)) {
+            if (filterKey === ITEM_ROOT) {
+              propName = propPrefix;
+            } else if (INDEXOF_REGEX.test(filterKey)) {
               propName = filterKey.replace(INDEXOF_REGEX, `(${propPrefix}/$1)`);
             } else if (FUNCTION_REGEX.test(filterKey)) {
               propName = filterKey.replace(FUNCTION_REGEX, `(${propPrefix}/$1)`);
@@ -490,7 +494,7 @@ function buildGroupBy<T>(groupBy: GroupBy<T>) {
 function buildOrderBy<T>(orderBy: OrderBy<T>, prefix: string = ''): string {
   if (Array.isArray(orderBy)) {
     return (orderBy as OrderByOptions<T>[])
-      .map(value => 
+      .map(value =>
         (Array.isArray(value) && value.length === 2 && ['asc', 'desc'].indexOf(value[1]) !== -1)? value.join(' ') : value
       )
       .map(v => `${prefix}${v}`).join(',');
@@ -506,7 +510,7 @@ function buildUrl(path: string, params: PlainObject): string {
   // This can be refactored using URL API. But IE does not support it.
   const queries: string[] = [];
   for (const key of Object.getOwnPropertyNames(params)) {
-    const value = params[key]; 
+    const value = params[key];
     if (value === 0 || !!value) {
       queries.push(`${key}=${value}`);
     }

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -703,6 +703,20 @@ describe('filter', () => {
       const actual = buildQuery({ filter });
       expect(actual).toEqual(expected);
     })
+
+    it('should handle collection operator with a function on the item of a simple collection', () => {
+      const filter = {
+        tags: {
+          any: {
+            [`tolower(${ITEM_ROOT})`]: 'tag1'
+          }
+        }
+      }
+      const expected =
+          "?$filter=tags/any(tags:tolower(tags) eq 'tag1')";
+      const actual = buildQuery({ filter });
+      expect(actual).toEqual(expected);
+    });
   });
 
   describe('data types', () => {

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -673,7 +673,7 @@ describe('filter', () => {
       expect(actual).toEqual(expected);
     })
 
-    it('should support "in" operator on a collection with an array/collection parameter of a strings', () => {
+    it('should handle collection operator with "in" operator on the item of a simple collection', () => {
       const filter = {
         tags: {
           any: {
@@ -682,6 +682,24 @@ describe('filter', () => {
         },
       };
       const expected = "?$filter=tags/any(tags:tags in ('tag1','tag2'))";
+      const actual = buildQuery({ filter });
+      expect(actual).toEqual(expected);
+    })
+
+
+    it('should handle collection operator with "or" operator on the item of a simple collection', () => {
+      const filter = {
+        tags: {
+          any: {
+            or: [
+              { [ITEM_ROOT]: 'tag1'},
+              { [ITEM_ROOT]: 'tag2'},
+            ]
+          }
+        }
+      };
+
+      const expected = "?$filter=tags/any(tags:((tags eq 'tag1') or (tags eq 'tag2')))";
       const actual = buildQuery({ filter });
       expect(actual).toEqual(expected);
     })

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1,4 +1,4 @@
-import buildQuery, { Expand, OrderBy, alias, json } from '../src/index';
+import buildQuery, {Expand, OrderBy, alias, json, ITEM_ROOT} from '../src/index';
 
 it('should return an empty string by default', () => {
   expect(buildQuery()).toEqual('');
@@ -669,6 +669,19 @@ describe('filter', () => {
         }
       };      
       const expected = "?$filter=MacAddress/all(macaddress: macaddress ne '3C:4A:92:F1:98:E2')";
+      const actual = buildQuery({ filter });
+      expect(actual).toEqual(expected);
+    })
+
+    it('should support "in" operator on a collection with an array/collection parameter of a strings', () => {
+      const filter = {
+        tags: {
+          any: {
+            [ITEM_ROOT]: { in: ['tag1', 'tag2']},
+          },
+        },
+      };
+      const expected = "?$filter=tags/any(tags:tags in ('tag1','tag2'))";
       const actual = buildQuery({ filter });
       expect(actual).toEqual(expected);
     })


### PR DESCRIPTION
#### Current behavior
```js
const filter = {
    tags: {
        any: {
            'tags': {
                'in': [TAG1', 'TAG2']
            }
        }
    }
}

buildQuery({ filter }) => "tags/any(tags:tags/tags in ('TAG1', 'TAG2'))"; 

``` 
#### Expected behavior ( [OData specification](https://docs.microsoft.com/en-us/azure/search/search-query-odata-collection-operators#examples))
```js
buildQuery({ filter }) => "tags/any(tags:tags in ('TAG1', 'TAG2'))"; 
``` 

To omit extra `/tags` in query, special const `ITEM_ROOT` was added.


What do you think about the idea?
