### PR TITLE
Support for collections without nested property key (fix for 'and' operator, updates in README)

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,7 +261,7 @@ buildQuery({ filter })
 => "?$filter=tags/any(tags:((tags eq 'tag1') or (tags eq 'tag2')))";
 ```
 
-'and' operator on collection item itself 
+'and' operator on collection item itself and nested item
 ```js
  const filter = {
     tags: {

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ See [tests](src/index.test.js) for examples as well
   - [Collection operators](#collection-operators) - `any`, `all`
     - [Implied and with an object or array of objects](#implied-and)
     - [Explicit operator (`and`, `or`, and `not`)](#explicit-operator-and-or)
+    - [Implied all operators on collection item itself](#implied-all-operators-on-collection-item-itself)
   - [Functions](#functions)
     - [String functions returning boolean](#string-functions-returning-boolean)
     - [Functions returning non-boolean values (string, int)](#functions-returning-non-boolean-values-string-int)
@@ -225,6 +226,68 @@ const filter = {
 
 buildQuery({ filter })
 => '?$filter=not ItemsProp/any(i:((i/SomeProp eq 1) or (i/AnotherProp eq 2)))'
+```
+
+##### Implied all operators on collection item itself 
+ITEM_ROOT is special constant to mark collection with primitive type
+
+'in' operator
+```js
+const filter = {
+    tags: {
+      any: {
+        [ITEM_ROOT]: { in: ['tag1', 'tag2']},
+      },
+    },
+};
+
+buildQuery({ filter })
+=> "?$filter=tags/any(tags:tags in ('tag1','tag2'))"
+```
+'or' operator on collection item itself
+```js
+const filter = {
+    tags: {
+      any: {
+        or: [
+          { [ITEM_ROOT]: 'tag1'},
+          { [ITEM_ROOT]: 'tag2'},
+        ]
+      }
+    }
+};
+
+buildQuery({ filter })
+=> "?$filter=tags/any(tags:((tags eq 'tag1') or (tags eq 'tag2')))";
+```
+
+'and' operator on collection item itself 
+```js
+ const filter = {
+    tags: {
+      any: [
+          { [ITEM_ROOT]: 'tag1'},
+          { [ITEM_ROOT]: 'tag2'},
+          { prop: 'tag3'},
+        ]
+    }
+};
+
+buildQuery({ filter });
+=> "?$filter=tags/any(tags:tags eq 'tag1' and tags eq 'tag2' and tags/prop eq 'tag3')";
+```
+Function on collection item itself 
+```js
+const filter = {
+    tags: {
+      any: {
+        [`tolower(${ITEM_ROOT})`]: 'tag1'
+      }
+    }
+};
+
+buildQuery({ filter });
+=> "?$filter=tags/any(tags:tolower(tags) eq 'tag1')";
 ```
 
 Supported operators: `any`, `all`

--- a/src/index.ts
+++ b/src/index.ts
@@ -208,7 +208,7 @@ function buildFilter(filters: Filter = {}, propPrefix = ''): string {
           const value = (filter as any)[filterKey];
           let propName = '';
           if (propPrefix) {
-            if (filterKey === ITEM_ROOT || Array.isArray(filter)) {
+            if (filterKey === ITEM_ROOT) {
               propName = propPrefix;
             } else if (INDEXOF_REGEX.test(filterKey)) {
               propName = filterKey.replace(INDEXOF_REGEX, (_,$1)=>$1.trim() === ITEM_ROOT ? `(${propPrefix})` : `(${propPrefix}/${$1.trim()})`);

--- a/src/index.ts
+++ b/src/index.ts
@@ -327,17 +327,15 @@ function buildFilter(filters: Filter = {}, propPrefix = ''): string {
     return filterExpr;
   }
 
-	function buildCollectionClause(lambdaParameter: string, value: any, op: string, propName: string) {
-		let clause = '';
+  function buildCollectionClause(lambdaParameter: string, value: any, op: string, propName: string) {
+    let clause = '';
 
-		if (typeof value === 'string' || value instanceof String) {
-			clause = getStringCollectionClause(lambdaParameter, value, op, propName);
-		} else if (value) {
-
-		  // normalize {any:[{prop1: 1}, {prop2: 1}]} --> {any:{prop1: 1, prop2: 1}}; same for 'all',
-          // simple values collection: {any:[{'': 'simpleVal1'}, {'': 'simpleVal2'}]} --> {any:{'': ['simpleVal1', 'simpleVal2']}}; same for 'all',
-
-        const filterValue = Array.isArray(value) ?
+    if (typeof value === 'string' || value instanceof String) {
+      clause = getStringCollectionClause(lambdaParameter, value, op, propName);
+    } else if (value) {
+      // normalize {any:[{prop1: 1}, {prop2: 1}]} --> {any:{prop1: 1, prop2: 1}}; same for 'all',
+      // simple values collection: {any:[{'': 'simpleVal1'}, {'': 'simpleVal2'}]} --> {any:{'': ['simpleVal1', 'simpleVal2']}}; same for 'all',
+      const filterValue = Array.isArray(value) ?
           value.reduce((acc, item) => {
             if (item.hasOwnProperty(ITEM_ROOT)) {
               if (!acc.hasOwnProperty(ITEM_ROOT)) {
@@ -349,11 +347,11 @@ function buildFilter(filters: Filter = {}, propPrefix = ''): string {
             return {...acc, ...item}
           }, {}) : value;
 
-          const filter = buildFilterCore(filterValue, lambdaParameter);
-          clause = `${propName}/${op}(${filter ? `${lambdaParameter}:${filter}` : ''})`;
-		}
-		return clause;
-	}
+      const filter = buildFilterCore(filterValue, lambdaParameter);
+      clause = `${propName}/${op}(${filter ? `${lambdaParameter}:${filter}` : ''})`;
+    }
+    return clause;
+  }
 }
 
 function getStringCollectionClause(lambdaParameter: string, value: any, collectionOperator: string, propName: string) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -162,6 +162,10 @@ export default function <T>({
   return buildUrl(path, { $select, $search, $top, $skip, $skiptoken, $format, ...params });
 }
 
+function renderPrimitiveValue(key: string, val: any) {
+  return `${key} eq ${handleValue(val)}`
+}
+
 function buildFilter(filters: Filter = {}, propPrefix = ''): string {
   return ((Array.isArray(filters) ? filters : [filters])
     .reduce((acc: string[], filter) => {
@@ -200,7 +204,7 @@ function buildFilter(filters: Filter = {}, propPrefix = ''): string {
 
           if (filterKey === ITEM_ROOT && Array.isArray(value)) {
             return result.concat(
-                value.map((arrayValue: any) => `${propName} eq ${handleValue(arrayValue)}`)
+                value.map((arrayValue: any) => renderPrimitiveValue(propName, arrayValue))
             )
           }
 
@@ -210,7 +214,7 @@ function buildFilter(filters: Filter = {}, propPrefix = ''): string {
             value === null
           ) {
             // Simple key/value handled as equals operator
-            result.push(`${propName} eq ${handleValue(value)}`);
+            result.push(renderPrimitiveValue(propName, value));
           } else if (Array.isArray(value)) {
             const op = filterKey;
             const builtFilters = value
@@ -244,7 +248,7 @@ function buildFilter(filters: Filter = {}, propPrefix = ''): string {
             }
           } else if (value instanceof Object) {
             if ('type' in value) {
-              result.push(`${propName} eq ${handleValue(value)}`);
+              result.push(renderPrimitiveValue(propName, value));
             } else {
               const operators = Object.keys(value);
               operators.forEach(op => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -333,22 +333,24 @@ function buildFilter(filters: Filter = {}, propPrefix = ''): string {
 		if (typeof value === 'string' || value instanceof String) {
 			clause = getStringCollectionClause(lambdaParameter, value, op, propName);
 		} else if (value) {
-          // normalize {any:[{prop1: 1}, {prop2: 1}]} --> {any:{prop1: 1, prop2: 1}}; same for 'all',
-          // simple values collection: {any:[{'': 'simpleVal1'}, {'': 'simpleVal2'}]} --> {any:{'': ['simpleVal1', 'simpleVal2']}}; same for 'all',
-          const filterValue = Array.isArray(value) ?
-            value.reduce((acc, item) => {
-              if (item.hasOwnProperty(ITEM_ROOT)) {
-                if (!acc.hasOwnProperty(ITEM_ROOT)) {
-                  acc[ITEM_ROOT] = [];
-                }
-                acc[ITEM_ROOT].push(item[ITEM_ROOT])
-                return acc;
-              }
-              return {...acc, ...item}
-            }, {}) : value
 
-			const filter = buildFilterCore(filterValue, lambdaParameter);
-			clause = `${propName}/${op}(${filter ? `${lambdaParameter}:${filter}` : ''})`;
+		  // normalize {any:[{prop1: 1}, {prop2: 1}]} --> {any:{prop1: 1, prop2: 1}}; same for 'all',
+          // simple values collection: {any:[{'': 'simpleVal1'}, {'': 'simpleVal2'}]} --> {any:{'': ['simpleVal1', 'simpleVal2']}}; same for 'all',
+
+        const filterValue = Array.isArray(value) ?
+          value.reduce((acc, item) => {
+            if (item.hasOwnProperty(ITEM_ROOT)) {
+              if (!acc.hasOwnProperty(ITEM_ROOT)) {
+                acc[ITEM_ROOT] = [];
+              }
+              acc[ITEM_ROOT].push(item[ITEM_ROOT])
+              return acc;
+            }
+            return {...acc, ...item}
+          }, {}) : value;
+
+          const filter = buildFilterCore(filterValue, lambdaParameter);
+          clause = `${propName}/${op}(${filter ? `${lambdaParameter}:${filter}` : ''})`;
 		}
 		return clause;
 	}

--- a/src/index.ts
+++ b/src/index.ts
@@ -332,21 +332,21 @@ function buildFilter(filters: Filter = {}, propPrefix = ''): string {
 
 		if (typeof value === 'string' || value instanceof String) {
 			clause = getStringCollectionClause(lambdaParameter, value, op, propName);
-
 		} else if (value) {
-          const filterValue = Array.isArray(value)
-              ? value.reduce((acc, item) => {
-                if (item.hasOwnProperty(ITEM_ROOT)) {
-                  if (!acc.hasOwnProperty(ITEM_ROOT)) {
-                    acc[ITEM_ROOT] = [];
-                  }
-                  acc[ITEM_ROOT].push(item[ITEM_ROOT])
-                  return acc;
+          // normalize {any:[{prop1: 1}, {prop2: 1}]} --> {any:{prop1: 1, prop2: 1}}; same for 'all',
+          // simple values collection: {any:[{'': 'simpleVal1'}, {'': 'simpleVal2'}]} --> {any:{'': ['simpleVal1', 'simpleVal2']}}; same for 'all',
+          const filterValue = Array.isArray(value) ?
+            value.reduce((acc, item) => {
+              if (item.hasOwnProperty(ITEM_ROOT)) {
+                if (!acc.hasOwnProperty(ITEM_ROOT)) {
+                  acc[ITEM_ROOT] = [];
                 }
-                return {...acc, ...item}
-              }, {}) : value
+                acc[ITEM_ROOT].push(item[ITEM_ROOT])
+                return acc;
+              }
+              return {...acc, ...item}
+            }, {}) : value
 
-			// normalize {any:[{prop1: 1}, {prop2: 1}]} --> {any:{prop1: 1, prop2: 1}}; same for 'all'
 			const filter = buildFilterCore(filterValue, lambdaParameter);
 			clause = `${propName}/${op}(${filter ? `${lambdaParameter}:${filter}` : ''})`;
 		}

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -704,6 +704,22 @@ describe('filter', () => {
       expect(actual).toEqual(expected);
     })
 
+    it('should handle collection operator with "and" operator on the item of a simple collection', () => {
+      const filter = {
+        tags: {
+          any: [
+              { [ITEM_ROOT]: 'tag1'},
+              { [ITEM_ROOT]: 'tag2'},
+              { prop: 'tag3'},
+            ]
+        }
+      };
+
+      const expected = "?$filter=tags/any(tags:tags eq 'tag1' and tags eq 'tag2' and tags/prop eq 'tag3')";
+      const actual = buildQuery({ filter });
+      expect(actual).toEqual(expected);
+    })
+
     it('should handle collection operator with a function on the item of a simple collection', () => {
       const filter = {
         tags: {


### PR DESCRIPTION
Addition to PR [#72 ](https://github.com/techniq/odata-query/pull/72)
- fix for 'and' operator
- updates in README with examples for ability to use all filters on the item itself with collection operators (any / all) 