### PR TITLE
Has Operator, Aliases Refactoring and Undefined vs Null

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -144,14 +144,11 @@ export default function <T>({
       path += `/${func}`;
     } else if (typeof func === 'object') {
       const [funcName] = Object.keys(func);
-      const funcArgs = Object.keys(func[funcName]).reduce(
-        (acc: string[], item) => [...acc, `${item}=${handleValue(func[funcName][item], aliases)}`],
-        []
-      );
+      const funcArgs = handleValue(func[funcName] as Value, aliases);
 
       path += `/${funcName}`;
-      if (funcArgs.length) {
-        path += `(${funcArgs.join(',')})`;
+      if (funcArgs !== "") {
+        path += `(${funcArgs})`;
       }
     }
   }
@@ -387,8 +384,9 @@ function handleValue(value: Value, aliases?: Alias[]): any {
     } else if (value.type === 'json') {
         return escape(JSON.stringify(value.value));
     } else {
-      return Object.keys(value)
-        .map(k => `${k}=${handleValue(value[k], aliases)}`).join(',');
+      return Object.entries(value)
+        .filter(([, v]) => v !== undefined)
+        .map(([k, v]) => `${k}=${handleValue(v as Value, aliases)}`).join(',');
     }
     }
     return value;

--- a/src/index.ts
+++ b/src/index.ts
@@ -286,6 +286,8 @@ function buildFilter(filters: Filter = {}, propPrefix = ''): string {
                 } else if (COLLECTION_OPERATORS.indexOf(op) !== -1) {
                   const collectionClause = buildCollectionClause(filterKey.toLowerCase(), value[op], op, propName);
                   if (collectionClause) { result.push(collectionClause); }
+                } else if (op === 'has') {
+                  result.push(`${propName} ${op} ${handleValue(value[op])}`);
                 } else if (op === 'in') {
                   const resultingValues = Array.isArray(value[op])
                     ? value[op]

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -39,6 +39,14 @@ describe('filter', () => {
       expect(actual).toEqual(expected);
     });
 
+    it('should allow "has" operator', () => {
+      const filter = { SomeProp: { has: { type: "raw", value: "Sales.Pattern'Yellow'" } } };
+      const expected =
+        "?$filter=SomeProp has Sales.Pattern'Yellow'";
+      const actual = buildQuery({ filter });
+      expect(actual).toEqual(expected);
+    });
+
     it('should allow "in" operator', () => {
       const filter = { SomeProp: { in: [1, 2, 3] } };
       const expected =

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -302,12 +302,12 @@ describe('filter', () => {
       const filter = { DateProp: { ge: start, le: end } };
       let expected =
         '?$filter=DateProp ge @start and DateProp le @end&@start=2017-01-01T00:00:00.000Z&@end=2017-03-01T00:00:00.000Z';
-      let actual = buildQuery({ filter, aliases: [start, end] });
+      let actual = buildQuery({ filter });
       expect(actual).toEqual(expected);
       end.value = new Date(Date.UTC(2017, 5, 1));
       expected =
         '?$filter=DateProp ge @start and DateProp le @end&@start=2017-01-01T00:00:00.000Z&@end=2017-06-01T00:00:00.000Z';
-      actual = buildQuery({ filter, aliases: [start, end] });
+      actual = buildQuery({ filter });
       expect(actual).toEqual(expected);
     });
 
@@ -1616,7 +1616,7 @@ describe('function', () => {
     };
     const expected =
       "/Test(SomeCollection=@SomeCollection)?@SomeCollection=['Sean','Jason']";
-    const actual = buildQuery({ func, aliases: [someCollection] });
+    const actual = buildQuery({ func });
     expect(actual).toEqual(expected);
   });
 
@@ -1627,7 +1627,7 @@ describe('function', () => {
     };
     const expected =
       '/Test(SomeCollection=@SomeCollection)?@SomeCollection=%5B%7B%22Name%22%3A%22Sean%22%7D%2C%7B%22Name%22%3A%22Jason%22%7D%5D';
-    const actual = buildQuery({ func, aliases: [someCollection] });
+    const actual = buildQuery({ func });
     expect(actual).toEqual(expected);
   });
 });

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1580,6 +1580,20 @@ describe('function', () => {
     expect(actual).toEqual(expected);
   });
 
+  it('should support a function on a collection with one null parameter', () => {
+    const func = { Test: { One: 1, Two: null } };
+    const expected = '/Test(One=1,Two=null)';
+    const actual = buildQuery({ func });
+    expect(actual).toEqual(expected);
+  });
+
+  it('should support a function on a collection with undefined parameter', () => {
+    const func = { Test: { One: 1, Two: undefined } };
+    const expected = '/Test(One=1)';
+    const actual = buildQuery({ func });
+    expect(actual).toEqual(expected);
+  });
+
   it('should support a function on an entity with parameters', () => {
     const key = 1;
     const func = { Test: { One: 1, Two: 2 } };


### PR DESCRIPTION
A refactoring of the aliases to allow aliases on filters, functions, and key.
Aliases are values ​​that are collected during the querystring generation process.
Applying conditions based on the difference between undefined and null.
Null is a permitted value in OData queries, while undefined is removed from it.