### PR TITLE
Added support of decimal numbers

### DIFF
--- a/README.md
+++ b/README.md
@@ -329,6 +329,22 @@ const filter = f().eq('TypeId', '1')
                   .toString();
 buildQuery({ filter })
 ```
+#### Numbers
+Number can be represented as integer or double.
+
+Integer:
+```js
+const filter = { NumberProp: 1 };
+buildQuery({ filter })
+=> '?$filter=NumberProp eq 1';    
+```
+Double: 
+```js
+const filter = { NumberProp: 1.23 };
+buildQuery({ filter })
+=> '?$filter=NumberProp eq 1.23d';
+```
+
 
 #### Data types
 GUID:
@@ -351,6 +367,14 @@ const filter = { "someProp": { eq: { type: 'binary', value: 'YmluYXJ5RGF0YQ==' }
 buildQuery({ filter })
 => "?$filter=someProp eq binary'YmluYXJ5RGF0YQ=='"
 ```
+
+Decimal: 
+```js
+const filter = { "someProp": { eq: { type: 'decimal', value: '12.3456789' } } };
+buildQuery({ filter })
+=> "?$filter=someProp eq '12.3456789M'"
+```
+
 Note that as per OData specification, binary data is transmitted as a base64 encoded string. Refer to [Primitive Types in JSON Format](https://www.odata.org/documentation/odata-version-2-0/json-format/), and [binary representation](https://www.odata.org/documentation/odata-version-2-0/overview/).
 
 Other types coming soon

--- a/README.md
+++ b/README.md
@@ -329,22 +329,6 @@ const filter = f().eq('TypeId', '1')
                   .toString();
 buildQuery({ filter })
 ```
-#### Numbers
-Number can be represented as integer or double.
-
-Integer:
-```js
-const filter = { NumberProp: 1 };
-buildQuery({ filter })
-=> '?$filter=NumberProp eq 1';    
-```
-Double: 
-```js
-const filter = { NumberProp: 1.23 };
-buildQuery({ filter })
-=> '?$filter=NumberProp eq 1.23d';
-```
-
 
 #### Data types
 GUID:

--- a/src/index.ts
+++ b/src/index.ts
@@ -364,9 +364,7 @@ function handleValue(value: Value, aliases?: Alias[]): any {
   } else if (value instanceof Date) {
     return value.toISOString();
   } else if (typeof value === 'number') {
-    // Number.isInteger(value) is not supported by IE11
-    const isDouble = value % 1 !== 0;
-    return isDouble ? `${value}d`: value;
+    return value;
   } else if (Array.isArray(value)) {
     return `[${value.map(d => handleValue(d)).join(',')}]`;
   } else if (value === null) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -362,7 +362,9 @@ function handleValue(value: Value, aliases?: Alias[]): any {
   } else if (value instanceof Date) {
     return value.toISOString();
   } else if (typeof value === 'number') {
-    return value;
+    // Number.isInteger(value) is not supported by IE11
+    const isDecimal = value % 1 !== 0;
+    return isDecimal ? `${value}M`: value;
   } else if (Array.isArray(value)) {
     return `[${value.map(d => handleValue(d)).join(',')}]`;
   } else if (value === null) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -57,7 +57,8 @@ export type Duration = { type: 'duration'; value: any; }
 export type Binary = { type: 'binary'; value: any; }
 export type Json = { type: 'json'; value: any; }
 export type Alias = { type: 'alias'; name: string; value: any; }
-export type Value = string | Date | number | boolean | Raw | Guid | Duration | Binary | Json | Alias;
+export type Decimal = { type: 'decimal'; value: any; }
+export type Value = string | Date | number | boolean | Raw | Guid | Duration | Binary | Json | Alias | Decimal;
 
 export const raw = (value: string): Raw => ({ type: 'raw', value });
 export const guid = (value: string): Guid => ({ type: 'guid', value });
@@ -65,6 +66,7 @@ export const duration = (value: string): Duration => ({ type: 'duration', value 
 export const binary = (value: string): Binary => ({ type: 'binary', value });
 export const json = (value: PlainObject): Json => ({ type: 'json', value });
 export const alias = (name: string, value: PlainObject): Alias => ({ type: 'alias', name, value });
+export const decimal = (value: string): Decimal => ({ type: 'decimal', value });
 
 export type QueryOptions<T> = ExpandOptions<T> & {
   search: string;
@@ -363,36 +365,38 @@ function handleValue(value: Value, aliases?: Alias[]): any {
     return value.toISOString();
   } else if (typeof value === 'number') {
     // Number.isInteger(value) is not supported by IE11
-    const isDecimal = value % 1 !== 0;
-    return isDecimal ? `${value}M`: value;
+    const isDouble = value % 1 !== 0;
+    return isDouble ? `${value}d`: value;
   } else if (Array.isArray(value)) {
     return `[${value.map(d => handleValue(d)).join(',')}]`;
   } else if (value === null) {
     return value;
   } else if (typeof value === 'object') {
-    if (value.type === 'raw') {
-      return value.value;
-    } else if (value.type === 'guid') {
+    switch (value.type) {
+      case 'raw':
+      case 'guid':
         return value.value;
-    } else if (value.type === 'duration') {
+      case 'duration':
         return `duration'${value.value}'`;
-    } else if (value.type === 'binary') {
+      case 'binary':
         return `binary'${value.value}'`;
-    } else if (value.type === 'alias') {
-      // Store
-      if (Array.isArray(aliases))
-        aliases.push(value as Alias);
-      return `@${(value as Alias).name}`;
-    } else if (value.type === 'json') {
+      case 'alias':
+        // Store
+        if (Array.isArray(aliases))
+          aliases.push(value as Alias);
+        return `@${(value as Alias).name}`;
+      case 'json':
         return escape(JSON.stringify(value.value));
-    } else {
-      return Object.entries(value)
-        .filter(([, v]) => v !== undefined)
-        .map(([k, v]) => `${k}=${handleValue(v as Value, aliases)}`).join(',');
+      case 'decimal':
+        return `${value.value}M`;
+      default:
+        return Object.entries(value)
+            .filter(([, v]) => v !== undefined)
+            .map(([k, v]) => `${k}=${handleValue(v as Value, aliases)}`).join(',');
     }
-    }
-    return value;
   }
+  return value;
+}
 
 function buildExpand<T>(expands: Expand<T>): string {
   if (typeof expands === 'number') {

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1,4 +1,4 @@
-import buildQuery, {Expand, OrderBy, alias, json, ITEM_ROOT} from '../src/index';
+import buildQuery, {Expand, OrderBy, alias, json, ITEM_ROOT, decimal} from '../src/index';
 
 it('should return an empty string by default', () => {
   expect(buildQuery()).toEqual('');
@@ -751,9 +751,16 @@ describe('filter', () => {
       expect(actual).toEqual(expected);
     });
 
-    it('should handle a decimal number', () => {
+    it('should handle double number', () => {
       const filter = { NumberProp: 1.23 };
-      const expected = '?$filter=NumberProp eq 1.23M';
+      const expected = '?$filter=NumberProp eq 1.23d';
+      const actual = buildQuery({ filter });
+      expect(actual).toEqual(expected);
+    });
+
+    it('should handle decimal number', () => {
+      const filter = { NumberProp: decimal('1.23456789') };
+      const expected = '?$filter=NumberProp eq 1.23456789M';
       const actual = buildQuery({ filter });
       expect(actual).toEqual(expected);
     });

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -751,6 +751,13 @@ describe('filter', () => {
       expect(actual).toEqual(expected);
     });
 
+    it('should handle a decimal number', () => {
+      const filter = { NumberProp: 1.23 };
+      const expected = '?$filter=NumberProp eq 1.23M';
+      const actual = buildQuery({ filter });
+      expect(actual).toEqual(expected);
+    });
+
     it('should handle a string', () => {
       const filter = { StringProp: '2' };
       const expected = "?$filter=StringProp eq '2'";

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -751,13 +751,6 @@ describe('filter', () => {
       expect(actual).toEqual(expected);
     });
 
-    it('should handle double number', () => {
-      const filter = { NumberProp: 1.23 };
-      const expected = '?$filter=NumberProp eq 1.23d';
-      const actual = buildQuery({ filter });
-      expect(actual).toEqual(expected);
-    });
-
     it('should handle decimal number', () => {
       const filter = { NumberProp: decimal('1.23456789') };
       const expected = '?$filter=NumberProp eq 1.23456789M';


### PR DESCRIPTION
According to oData documentation decimal number should be represented as `[0-9]+.[0-9]+M|m`