### PR TITLE
Handle Typed Property Name in Filter - Issue #95

### DIFF
--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1,4 +1,5 @@
-import buildQuery, {Expand, OrderBy, alias, json, ITEM_ROOT, decimal} from '../src/index';
+import buildQuery, {Expand, OrderBy, alias, json, ITEM_ROOT, decimal, TypedFilter } from '../src/index';
+import { Square } from './test-interface'; 
 
 it('should return an empty string by default', () => {
   expect(buildQuery()).toEqual('');
@@ -35,6 +36,32 @@ describe('filter', () => {
       ];
       const expected =
         "?$filter=SomeProp eq 1 and AnotherProp eq 2 and startswith(Name, 'R')";
+      const actual = buildQuery({ filter });
+      expect(actual).toEqual(expected);
+    });
+    
+    it('should handle basic typed filter without operator', () => {
+      const filter: TypedFilter<Square> = { Height: 1 };
+      const expected = '?$filter=Height eq 1';
+      const actual = buildQuery({ filter });
+      expect(actual).toEqual(expected);
+    });
+
+    it('should handle typed filter with operator', () => {
+      const filter: TypedFilter<Square> = { Height: { lt: 5 } };
+      const expected = '?$filter=Height lt 5';
+      const actual = buildQuery({ filter });
+      expect(actual).toEqual(expected);
+    });
+
+    it('should allow passing filter as an array of typed filters and strings', () => {
+      const filter: Array<TypedFilter<Square> | string> = [
+        { Height: 1 },
+        { Width: { lt: 5 } },
+        "startswith(Name, 'R')",
+      ];
+      const expected =
+        "?$filter=Height eq 1 and Width lt 5 and startswith(Name, 'R')";
       const actual = buildQuery({ filter });
       expect(actual).toEqual(expected);
     });

--- a/test/test-interface.ts
+++ b/test/test-interface.ts
@@ -1,0 +1,4 @@
+export interface Square {
+  Height: number;
+  Width: number;
+};


### PR DESCRIPTION
This changeset manages #95 and enhances the Filter type in order to build filter objects as `TypedFilter<T>` or `Array<string | PlainObject | TypedFilter<T>>`. In this way it would be possible to have type safety for the property name. 
Please note that: 
- the type of each and every key in the TypedFilter is `any` in order to support oData operator passed as a plain object. 
- the changes do not support property name type safety for nested properties
