### PR TITLE
Fix: bad operator precedence inside object

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -246,7 +246,7 @@ function buildFilter(filters: Filter = {}, aliases: Alias[] = [], propPrefix = '
               if (op === 'not') {
                 result.push(parseNot(builtFilters as string[]));
               } else {
-                result.push(`${builtFilters.join(` ${op} `)}`);
+                result.push(`(${builtFilters.join(` ${op} `)})`);
               }
             }
           } else if (typeof value === 'object') {

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -208,7 +208,7 @@ describe('filter', () => {
 
     it('should handle simple logical operators (and, or, etc) as an object (no parens)', () => {
       const filter = { and: { SomeProp: 1, AnotherProp: 2 } };
-      const expected = '?$filter=SomeProp eq 1 and AnotherProp eq 2';
+      const expected = '?$filter=(SomeProp eq 1 and AnotherProp eq 2)';
       const actual = buildQuery({ filter });
       expect(actual).toEqual(expected);
     });
@@ -323,7 +323,7 @@ describe('filter', () => {
           },
         ],
       };
-      const expected = '?$filter=((Prop1 eq 1) or (Prop2 eq 2 and Prop3 eq 3))';
+      const expected = '?$filter=((Prop1 eq 1) or ((Prop2 eq 2 and Prop3 eq 3)))';
       const actual = buildQuery({ filter });
       expect(actual).toEqual(expected);
     });

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -327,6 +327,19 @@ describe('filter', () => {
       const actual = buildQuery({ filter });
       expect(actual).toEqual(expected);
     });
+    
+    it('should have parens in nested logical operators', () => {
+      const filter = {
+        Prop1: 1,
+        or: {
+          Prop2: 2,
+          Prop3: 3,
+        },
+      };
+      const expected = '?$filter=Prop1 eq 1 and (Prop2 eq 2 and Prop3 eq 3)';
+      const actual = buildQuery({ filter });
+      expect(actual).toEqual(expected);
+    });
 
     it('should handle nested properties using "/" selectors', () => {
       const filter = {

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -336,7 +336,7 @@ describe('filter', () => {
           Prop3: 3,
         },
       };
-      const expected = '?$filter=Prop1 eq 1 and (Prop2 eq 2 and Prop3 eq 3)';
+      const expected = '?$filter=Prop1 eq 1 and (Prop2 eq 2 or Prop3 eq 3)';
       const actual = buildQuery({ filter });
       expect(actual).toEqual(expected);
     });


### PR DESCRIPTION
This filter:
```js
{ 
  a: 1, 
  or: { b: 2, c: 3 },
}
```
was incorrectly converted to: `a eq 1 and b eq 2 or c eq 3`.

Brackets are required to fix the precedence of `or` as expressed in the object structure.

After this fix:
`a eq 1 and (b eq 2 or c eq 3)`