### PR TITLE
Issue #107 - Add $skip support to Expand options

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ const SUPPORTED_EXPAND_PROPERTIES = [
   'expand',
   'levels',
   'select',
+  'skip',
   'top',
   'count',
   'orderby',
@@ -36,6 +37,7 @@ export type ExpandOptions<T> = {
   select: Select<T>;
   filter: Filter;
   orderBy: OrderBy<T>;
+  skip: number;
   top: number;
   levels: number | 'max';
   count: boolean | Filter;
@@ -449,6 +451,7 @@ function buildExpand<T>(expands: Expand<T>): string {
               break;
             case 'levels':
             case 'count':
+            case 'skip':
             case 'top':
               value = `${(expands as NestedExpandOptions<any>)[key]}`;
               break;

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1501,6 +1501,13 @@ describe('expand', () => {
     expect(actual).toEqual(expected);
   });
 
+  it('should allow expand with skip', () => {
+    const expand = { Friends: { skip: 10 } };
+    const expected = '?$expand=Friends($skip=10)';
+    const actual = buildQuery({ expand });
+    expect(actual).toEqual(expected);
+  });
+
   it('should allow expand with top', () => {
     const expand = { Friends: { top: 10 } };
     const expected = '?$expand=Friends($top=10)';


### PR DESCRIPTION
Add $skip support to Expand options
Fix #107 