### PR TITLE
fix #109 allow selecting multiple unknown properties

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -17,7 +17,7 @@ const FUNCTION_REGEX = /\((.*)\)/;
 const INDEXOF_REGEX = /(?!indexof)\((\w+)\)/;
 
 export type PlainObject = { [property: string]: any };
-export type Select<T> = string | keyof T | Array<keyof T>;
+export type Select<T> = string | string[] | keyof T | Array<keyof T>;
 export type NestedOrderBy<T> = { [P in keyof T]?: T[P] extends Array<infer E> ? OrderBy<E> : OrderBy<T[P]> }
 export type OrderBy<T> = string | OrderByOptions<T> | Array<OrderByOptions<T>> | NestedOrderBy<T>;
 export type Filter = string | PlainObject | Array<string | PlainObject>;


### PR DESCRIPTION
It fixes both issues mentioned in #109. We can `select` unknown properties and autocomplete for properties defined using `orderBy` or `expand` still works.

![Screenshot 2023-03-08 at 16 57 16](https://user-images.githubusercontent.com/58401630/223763375-94a1610d-a41d-4c66-94c5-89a5a9f40ea6.png)

![Screenshot 2023-03-08 at 16 57 34](https://user-images.githubusercontent.com/58401630/223763459-3f426c6f-3504-4972-b9a3-5cd9ae8fa6c8.png)
