### PR TITLE
fix: added SPACE after NOT

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -570,5 +570,5 @@ function buildUrl(path: string, params: PlainObject): string {
 }
 
 function parseNot(builtFilters: string[]): string {
-  return `not(${builtFilters.join(' and ')})`;
+  return `not (${builtFilters.join(' and ')})`;
 }

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -106,7 +106,7 @@ describe('filter', () => {
     it('allows "in" operator in negated case', () => {
       const filter = { not: { SomeProp: { in: [1, 2, 3] } } };
       const expected =
-        '?$filter=not(SomeProp in (1,2,3))';
+        '?$filter=not (SomeProp in (1,2,3))';
       const actual = buildQuery({ filter });
       expect(actual).toEqual(expected);
     });
@@ -171,7 +171,7 @@ describe('filter', () => {
         ],
       };
       const expected =
-        "?$filter=((not(startswith(FooProp,'foo'))) and (not(startswith(BarProp,'bar'))) and (startswith(FooBarProp,'foobar')))";
+        "?$filter=((not (startswith(FooProp,'foo'))) and (not (startswith(BarProp,'bar'))) and (startswith(FooBarProp,'foobar')))";
       const actual = buildQuery({ filter });
       expect(actual).toEqual(expected);
     });
@@ -189,7 +189,7 @@ describe('filter', () => {
         ],
       };
       const expected =
-        "?$filter=((not(startswith(FooProp,'foo') and startswith(BarProp,'bar'))) and (startswith(FooBarProp,'bar')))";
+        "?$filter=((not (startswith(FooProp,'foo') and startswith(BarProp,'bar'))) and (startswith(FooBarProp,'bar')))";
       const actual = buildQuery({ filter });
       expect(actual).toEqual(expected);
     });
@@ -203,7 +203,7 @@ describe('filter', () => {
         ],
       };
       const expected =
-        "?$filter=not((startswith(FooProp,'foo')) and (startswith(BarProp,'bar')) and (FizProp in (1,2,3)))";
+        "?$filter=not ((startswith(FooProp,'foo')) and (startswith(BarProp,'bar')) and (FizProp in (1,2,3)))";
       const actual = buildQuery({ filter });
       expect(actual).toEqual(expected);
     });
@@ -221,7 +221,7 @@ describe('filter', () => {
         ],
       };
       const expected =
-        "?$filter=((not((startswith(FooProp,'foo')) and (startswith(BarProp,'bar')) and (FizProp in (1,2,3)))))";
+        "?$filter=((not ((startswith(FooProp,'foo')) and (startswith(BarProp,'bar')) and (FizProp in (1,2,3)))))";
       const actual = buildQuery({ filter });
       expect(actual).toEqual(expected);
     });


### PR DESCRIPTION
According to Oasis ABNF for OData, not operator must be followed by RWS, a.k.a. a required whitespace.
The library puts no space between not and the following brackets ().

This PR is to fix this issue.