### PR TITLE
feat: support matchesPattern boolean function

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,7 +295,7 @@ const filter = { PropName: { contains: 'foo' } };
 buildQuery({ filter })
 => "$filter=contains(PropName,'foo')"
 ```
-Supported operators: `startswith`, `endswith`, `contains`
+Supported operators: `startswith`, `endswith`, `contains`, `matchespattern`
 
 ##### Functions returning non-boolean values (string, int)
 ```js

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 const COMPARISON_OPERATORS = ['eq', 'ne', 'gt', 'ge', 'lt', 'le'];
 const LOGICAL_OPERATORS = ['and', 'or', 'not'];
 const COLLECTION_OPERATORS = ['any', 'all'];
-const BOOLEAN_FUNCTIONS = ['startswith', 'endswith', 'contains'];
+const BOOLEAN_FUNCTIONS = ['startswith', 'endswith', 'contains', 'matchespattern'];
 const SUPPORTED_EXPAND_PROPERTIES = [
   'expand',
   'levels',
@@ -295,7 +295,7 @@ function buildFilter<T>(filters: Filter<T> = {}, aliases: Alias[] = [], propPref
                     propName + ' in (' + resultingValues.map((v: any) => handleValue(v, aliases)).join(',') + ')'
                   );
                 } else if (BOOLEAN_FUNCTIONS.indexOf(op) !== -1) {
-                  // Simple boolean functions (startswith, endswith, contains)
+                  // Simple boolean functions (startswith, endswith, contains, matchespattern)
                   result.push(`${op}(${propName},${handleValue(value[op], aliases)})`);
                 } else {
                   // Nested property


### PR DESCRIPTION
Adds support for the [`matchesPattern`](https://docs.oasis-open.org/odata/odata/v4.01/odata-v4.01-part2-url-conventions.html#sec_matchesPattern) boolean odata function.