### PR TITLE
fix: prevent duplicated conditions & restore skipped tests

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -111,7 +111,7 @@ export default function <T>({
   // key is not (null, undefined)
   if (key != undefined) {
     path += `(${handleValue(key as Value, aliases)})`;
-    }
+  }
 
   if (filter || typeof count === 'object')
     params.$filter = buildFilter(typeof count === 'object' ? count : filter, aliases);
@@ -195,7 +195,7 @@ function buildFilter<T>(filters: Filter<T> = {}, aliases: Alias[] = [], propPref
           const value = (filter as any)[filterKey];
           if (value === undefined) {
             return result;
-	  }
+          }
 
           let propName = '';
           if (propPrefix) {
@@ -214,7 +214,7 @@ function buildFilter<T>(filters: Filter<T> = {}, aliases: Alias[] = [], propPref
 
           if (filterKey === ITEM_ROOT && Array.isArray(value)) {
             return result.concat(
-                value.map((arrayValue: any) => renderPrimitiveValue(propName, arrayValue))
+              value.map((arrayValue: any) => renderPrimitiveValue(propName, arrayValue))
             )
           }
 
@@ -299,7 +299,7 @@ function buildFilter<T>(filters: Filter<T> = {}, aliases: Alias[] = [], propPref
                   result.push(`${op}(${propName},${handleValue(value[op], aliases)})`);
                 } else {
                   // Nested property
-                  const filter = buildFilterCore(value, aliases, propName);
+                  const filter = buildFilterCore({ [op]: value[op] }, aliases, propName);
                   if (filter) {
                     result.push(filter);
                   }
@@ -350,11 +350,11 @@ function buildFilter<T>(filters: Filter<T> = {}, aliases: Alias[] = [], propPref
 }
 
 function getStringCollectionClause(lambdaParameter: string, value: any, collectionOperator: string, propName: string) {
-	let clause = '';
-	const conditionOperator = collectionOperator == 'all' ? 'ne' : 'eq';
-	clause = `${propName}/${collectionOperator}(${lambdaParameter}: ${lambdaParameter} ${conditionOperator} '${value}')`
+  let clause = '';
+  const conditionOperator = collectionOperator == 'all' ? 'ne' : 'eq';
+  clause = `${propName}/${collectionOperator}(${lambdaParameter}: ${lambdaParameter} ${conditionOperator} '${value}')`
 
-	return clause;
+  return clause;
 }
 
 function escapeIllegalChars(string: string) {

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -132,7 +132,7 @@ describe('filter', () => {
       expect(actual).toEqual(expected);
     });
 
-    it.skip('should handle nested properties on the same property (implicit "and")', () => {
+    it('should handle nested properties on the same property (implicit "and")', () => {
       const filter = {
         SomeProp: {
           NestedProp1: 1,
@@ -140,7 +140,7 @@ describe('filter', () => {
         },
       };
       const expected =
-        '?$filter=(SomeProp/NestedProp1 eq 1 and SomeProp/NestedProp2 eq 2)';
+        '?$filter=SomeProp/NestedProp1 eq 1 and SomeProp/NestedProp2 eq 2';
       const actual = buildQuery({ filter });
       expect(actual).toEqual(expected);
     });
@@ -466,8 +466,7 @@ describe('filter', () => {
       expect(actual).toEqual(expected);
     });
 
-    // TODO: duplicating filter clauses `(Prop2/NestedProp2/DeeplyNestedProp2 eq 2 and Prop2/NestedProp3 ne null)`.  Still logically the same result
-    it.skip('should handle nested logical operators and deeply nested properties on same property using objects (shorthand)', () => {
+    it('should handle nested logical operators and deeply nested properties on same property using objects (shorthand)', () => {
       const filter = {
         Prop1: {
           NestedProp1: 1,


### PR DESCRIPTION
@techniq This fixes the problem you called out in your `TODO` comments within the tests where conditions were being duplicated.  The duplicated are no longer included when building the query, and I've restored the skipped tests.