### PR TITLE
build: run tsc and vite build sequentially

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   },
   "scripts": {
     "prepare": "pnpm run build",
-    "build": "tsc -p tsconfig.esm.json & npx vite build",
+    "build": "tsc --listEmittedFiles -p tsconfig.esm.json && npx vite build",
     "test": "vitest run",
     "test-watch": "vitest",
     "preversion": "pnpm run build",


### PR DESCRIPTION
it seems possible that on CI the backgrounded  command is not finishing and that's why the d.ts files are not included in the release? Ether way, it doesn't seem necessary to background the task