### PR TITLE
build: re-order tsc and vite

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   },
   "scripts": {
     "prepare": "pnpm run build",
-    "build": "tsc --listEmittedFiles -p tsconfig.esm.json && npx vite build",
+    "build": "npx vite build && tsc --listEmittedFiles -p tsconfig.esm.json && ls -R dist",
     "test": "vitest run",
     "test-watch": "vitest",
     "preversion": "pnpm run build",


### PR DESCRIPTION
locally if I run `NODE_ENV=production CI=true pnpm build` I see the .d.ts file appear in list and then it's deleted when `vite build` runs. Re-ordering fixes the issues.

This might fix #132 